### PR TITLE
makes project more Go idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![GoDoc](https://godoc.org/github.com/VoltDB/voltdb-client-go?status.svg)](https://godoc.org/github.com/VoltDB/voltdb-client-go) 
+
 VoltDB Golang Client Library
 =========================
 
@@ -9,7 +11,7 @@ Client API
 =========================
 
 The VoltDB golang client implements the interfaces specified in the database/sql/driver
-package.  The interfaces specified by database/sql/driver are typically used to implement 
+package.  The interfaces specified by database/sql/driver are typically used to implement
 a driver to be used with the golang database/sql package.
 
 The code here can be used as a driver in this manner; it can also be used as a stand
@@ -27,7 +29,7 @@ The VoltDB golang client is built in the standard go manner.
 Examples
 =========================
 The VoltDB golang client includes three examples.  There is a simple hello world example
-and a similar example that uses the asynchronous api.  There is also an example that 
+and a similar example that uses the asynchronous api.  There is also an example that
 uses the client with the database/sql/driver api only.
 
 Wire Protocol

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GoDoc](https://godoc.org/github.com/VoltDB/voltdb-client-go?status.svg)](https://godoc.org/github.com/VoltDB/voltdb-client-go) 
+[![GoDoc](https://godoc.org/github.com/VoltDB/voltdb-client-go/voltdbclient?status.svg)](https://godoc.org/github.com/VoltDB/voltdb-client-go/voltdbclient) 
 
 VoltDB Golang Client Library
 =========================

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,13 +5,17 @@ Hello World
 
 First, follow the instructions in the VoltDB kit's doc/tutorials/helloworld folder to start the database and load the schema.
 
-Then, go to hello-world folder, run one the following commands to start the go helloworld client.  
-This requires no arguments and connects to localhost.
+Then, go to hello-world folder, go into the preferred example folder:
+
+  - async (for using low-level async call API)
+  - sync (for using low-level sync call API)
+  - driver (for using high-level Go database/sql API)
+
+Run the following command to start the go helloworld client.  
+*This requires no arguments and connects to localhost.*
 
 ```
-go run async_hello_world.go (for using low-level async call API)
-go run sync_hello_world.go  (for using low-level sync call API)
-go run driver_hello_world.go (for using high-level go sql API)
+go run hello_world.go
 ```
 
 Voter

--- a/examples/hello-world/async/hello_world.go
+++ b/examples/hello-world/async/hello_world.go
@@ -21,10 +21,11 @@ package main
 import (
 	"database/sql/driver"
 	"fmt"
-	"github.com/VoltDB/voltdb-client-go/voltdbclient"
 	"log"
 	"math/rand"
 	"os"
+
+	"github.com/VoltDB/voltdb-client-go/voltdbclient"
 )
 
 func main() {

--- a/examples/hello-world/async/hello_world.go
+++ b/examples/hello-world/async/hello_world.go
@@ -46,7 +46,7 @@ func main() {
 	// conn, err := voltdbclient.OpenConnWithMaxOutstandingTxns([]string{"localhost:21212"}, 20)
 
 	conn.Exec("@AdHoc", []driver.Value{"DELETE FROM HELLOWORLD;"})
-	resCons := ResponseConsumer{}
+	resCons := responseConsumer{}
 
 	conn.ExecAsync(resCons, "HELLOWORLD.insert", []driver.Value{"Bonjour", "Monde", "French"})
 	conn.ExecAsync(resCons, "HELLOWORLD.insert", []driver.Value{"Hello", "World", "English"})
@@ -71,19 +71,19 @@ func main() {
 	conn.Drain()
 }
 
-type ResponseConsumer struct{}
+type responseConsumer struct{}
 
-func (rc ResponseConsumer) ConsumeError(err error) {
+func (rc responseConsumer) ConsumeError(err error) {
 	fmt.Println(err)
 }
 
-func (rc ResponseConsumer) ConsumeResult(res driver.Result) {
+func (rc responseConsumer) ConsumeResult(res driver.Result) {
 	ra, _ := res.RowsAffected()
 	lid, _ := res.LastInsertId()
 	fmt.Printf("%d, %d\n", ra, lid)
 }
 
-func (rc ResponseConsumer) ConsumeRows(rows driver.Rows) {
+func (rc responseConsumer) ConsumeRows(rows driver.Rows) {
 	vrows := rows.(voltdbclient.VoltRows)
 	vrows.AdvanceRow()
 	iHello, err := vrows.GetStringByName("HELLO")

--- a/examples/hello-world/driver/hello_world.go
+++ b/examples/hello-world/driver/hello_world.go
@@ -18,8 +18,8 @@
 // A simple example that demonstrates the use of the VoltDB database/sql/driver.
 package main
 
-import "database/sql"
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"os"

--- a/examples/hello-world/sync/hello_world.go
+++ b/examples/hello-world/sync/hello_world.go
@@ -21,9 +21,10 @@ package main
 import (
 	"database/sql/driver"
 	"fmt"
-	"github.com/VoltDB/voltdb-client-go/voltdbclient"
 	"log"
 	"os"
+
+	"github.com/VoltDB/voltdb-client-go/voltdbclient"
 )
 
 func main() {

--- a/examples/voltkv/kv_config.go
+++ b/examples/voltkv/kv_config.go
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package main
 
 import (
@@ -25,6 +26,7 @@ import (
 
 type runType string
 
+// runTypes
 const (
 	ASYNC runType = "async"
 	SYNC  runType = "sync"
@@ -56,7 +58,7 @@ type kvConfig struct {
 	runtype         runType
 }
 
-func NewKVConfig() (*kvConfig, error) {
+func newKVConfig() (*kvConfig, error) {
 	kv := new(kvConfig)
 	flag.DurationVar(&(kv.displayinterval), "displayinterval", 5*time.Second, "Interval for performance feedback, in seconds.")
 	flag.DurationVar(&(kv.duration), "duration", 120*time.Second, "Benchmark duration, in seconds.")

--- a/examples/voltkv/payload_processor.go
+++ b/examples/voltkv/payload_processor.go
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package main
 
 import (
@@ -37,11 +38,11 @@ type payLoadProcessor struct {
 }
 
 // var entropyBytesGlobal bytes.Buffer = new(bytes.Buffer)
-const ENTROPY_BYTE_SIZE int = 1024 * 1024 * 4
+const entropyByteSize int = 1024 * 1024 * 4
 
 var entropyBytes *bytes.Reader
 
-func NewPayloadProcessor(keySize, minValueSize, maxValueSize, entropy, poolSize int, useCompression bool) *payLoadProcessor {
+func newPayloadProcessor(keySize, minValueSize, maxValueSize, entropy, poolSize int, useCompression bool) *payLoadProcessor {
 	rand.Seed(time.Now().UTC().UnixNano())
 	proc := new(payLoadProcessor)
 	proc.keySize = keySize
@@ -53,7 +54,7 @@ func NewPayloadProcessor(keySize, minValueSize, maxValueSize, entropy, poolSize 
 
 	proc.keyFormat = "K%" + strconv.Itoa(proc.keySize) + "v"
 	// rand.Seed()
-	b := make([]byte, ENTROPY_BYTE_SIZE)
+	b := make([]byte, entropyByteSize)
 	for i := range b {
 		b[i] = byte(rand.Intn(127) % entropy)
 	}
@@ -73,9 +74,8 @@ func (proc *payLoadProcessor) generateForStore() (key string, rawValue, storeVal
 	}
 	if proc.useCompression {
 		return key, rawValue, toGzip(rawValue)
-	} else {
-		return key, rawValue, rawValue
 	}
+	return key, rawValue, rawValue
 }
 
 func (proc *payLoadProcessor) generateRandomKeyForRetrieval() string {
@@ -85,9 +85,8 @@ func (proc *payLoadProcessor) generateRandomKeyForRetrieval() string {
 func (proc *payLoadProcessor) retrieveFromStore(storeValue []byte) ([]byte, []byte) {
 	if proc.useCompression {
 		return fromGzip(storeValue), storeValue
-	} else {
-		return storeValue, storeValue
 	}
+	return storeValue, storeValue
 }
 
 func fromGzip(compressed []byte) []byte {

--- a/examples/voter/phonecall_generator.go
+++ b/examples/voter/phonecall_generator.go
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package main
 
 import (
@@ -24,7 +25,7 @@ import (
 	"time"
 )
 
-var area_code_strs = strings.Split("907,205,256,334,251,870,501,479"+
+var areaCodeStrs = strings.Split("907,205,256,334,251,870,501,479"+
 	",480,602,623,928,520,341,764,628,831,925,909,562,661,510,650,949,760"+
 	",415,951,209,669,408,559,626,442,530,916,627,714,707,310,323,213,424"+
 	",747,818,858,935,619,805,369,720,303,970,719,860,203,959,475,202,302"+
@@ -44,12 +45,12 @@ var area_code_strs = strings.Split("907,205,256,334,251,870,501,479"+
 	",435,801,385,434,804,757,703,571,276,236,540,802,509,360,564,206,425"+
 	",253,715,920,262,414,608,304,307", ",")
 
-var area_code []int
+var areaCode []int
 
 func init() {
-	area_code = make([]int, len(area_code_strs))
-	for i, v := range area_code_strs {
-		area_code[i], _ = strconv.Atoi(v)
+	areaCode = make([]int, len(areaCodeStrs))
+	for i, v := range areaCodeStrs {
+		areaCode[i], _ = strconv.Atoi(v)
 	}
 }
 
@@ -58,11 +59,11 @@ type phoneCallGenerator struct {
 	votingMap       []int32
 }
 
-func NewPhoneCallGenerator(contestantCount int) phoneCallGenerator {
+func newPhoneCallGenerator(contestantCount int) phoneCallGenerator {
 	rand.Seed(time.Now().UTC().UnixNano())
 	pcg := new(phoneCallGenerator)
 	pcg.contestantCount = int32(contestantCount)
-	pcg.votingMap = make([]int32, len(area_code))
+	pcg.votingMap = make([]int32, len(areaCode))
 	for i := range pcg.votingMap {
 		pcg.votingMap[i] = 1
 		if rand.Intn(100) >= 30 {
@@ -78,7 +79,7 @@ func (pcg phoneCallGenerator) receive() (contestantNumber int32, phoneNumber int
 	// (including invalid votes to demonstrate transaction validationg in the database)
 
 	// Pick a random area code for the originating phone call
-	areaCodeIndex := rand.Intn(len(area_code))
+	areaCodeIndex := rand.Intn(len(areaCode))
 
 	// Pick a contestant number
 	contestantNumber = pcg.votingMap[areaCodeIndex]
@@ -93,7 +94,7 @@ func (pcg phoneCallGenerator) receive() (contestantNumber int32, phoneNumber int
 	}
 
 	// Build the phone number
-	phoneNumber = int64(area_code[areaCodeIndex])*10000000 + rand.Int63n(10000000)
+	phoneNumber = int64(areaCode[areaCodeIndex])*10000000 + rand.Int63n(10000000)
 
 	// Return the generated phone number
 	return contestantNumber, phoneNumber

--- a/examples/voter/voter_config.go
+++ b/examples/voter/voter_config.go
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package main
 
 import (
@@ -25,6 +26,7 @@ import (
 
 type runType string
 
+// runTypes
 const (
 	ASYNC runType = "async"
 	SYNC  runType = "sync"
@@ -53,7 +55,7 @@ type voterConfig struct {
 	runtype    runType
 }
 
-func NewVoterConfig() (*voterConfig, error) {
+func newVoterConfig() (*voterConfig, error) {
 	voter := new(voterConfig)
 	flag.DurationVar(&(voter.displayinterval), "displayinterval", 5*time.Second, "Interval for performance feedback, in seconds.")
 	flag.DurationVar(&(voter.duration), "duration", 120*time.Second, "Benchmark duration, in seconds.")

--- a/voltdbclient/authentication_test.go
+++ b/voltdbclient/authentication_test.go
@@ -26,9 +26,9 @@ import (
 func TestLoginRequest(t *testing.T) {
 	var loginBytes []byte
 	loginBuf := bytes.NewBuffer(loginBytes)
-	login, err := serializeLoginMessage("hello", "world")
+	login, err := serializeLoginMessage(protoVersion, "hello", "world")
 	check(t, err)
-	writeLoginMessage(loginBuf, &login)
+	writeLoginMessage(protoVersion, loginBuf, &login)
 
 	fileBytes, err := ioutil.ReadFile("./test_resources/authentication_request_sha256.msg")
 	check(t, err)

--- a/voltdbclient/client_affinity.go
+++ b/voltdbclient/client_affinity.go
@@ -19,15 +19,15 @@ package voltdbclient
 
 import (
 	"database/sql/driver"
-	"errors"
-	"strings"
 	"encoding/json"
+	"errors"
 	"math/rand"
+	"strings"
 )
 
 func (c *Conn) subscribeTopo(nc *nodeConn) <-chan voltResponse {
 	responseCh := make(chan voltResponse, 1)
-	SubscribeTopoPi := newSyncProcedureInvocation(c.getNextSystemHandle(), true, "@Subscribe", []driver.Value{"TOPOLOGY"}, responseCh, DEFAULT_QUERY_TIMEOUT)
+	SubscribeTopoPi := newSyncProcedureInvocation(c.getNextSystemHandle(), true, "@Subscribe", []driver.Value{"TOPOLOGY"}, responseCh, DefaultQueryTimeout)
 	nc.submit(SubscribeTopoPi)
 	return responseCh
 }
@@ -36,14 +36,14 @@ func (c *Conn) getTopoStatistics(nc *nodeConn) <-chan voltResponse {
 	// TODO add sysHandle to procedureInvocation
 	// system call procedure should bypass timeout and backpressure
 	responseCh := make(chan voltResponse, 1)
-	topoStatisticsPi := newSyncProcedureInvocation(c.getNextSystemHandle(), true, "@Statistics", []driver.Value{"TOPO", int32(JSON_FORMAT)}, responseCh, DEFAULT_QUERY_TIMEOUT)
+	topoStatisticsPi := newSyncProcedureInvocation(c.getNextSystemHandle(), true, "@Statistics", []driver.Value{"TOPO", int32(JSONFormat)}, responseCh, DefaultQueryTimeout)
 	nc.submit(topoStatisticsPi)
 	return responseCh
 }
 
 func (c *Conn) getProcedureInfo(nc *nodeConn) <-chan voltResponse {
 	responseCh := make(chan voltResponse, 1)
-	procedureInfoPi := newSyncProcedureInvocation(c.getNextSystemHandle(), true, "@SystemCatalog", []driver.Value{"PROCEDURES"}, responseCh, DEFAULT_QUERY_TIMEOUT)
+	procedureInfoPi := newSyncProcedureInvocation(c.getNextSystemHandle(), true, "@SystemCatalog", []driver.Value{"PROCEDURES"}, responseCh, DefaultQueryTimeout)
 	nc.submit(procedureInfoPi)
 	return responseCh
 }
@@ -67,8 +67,8 @@ func (c *Conn) updateAffinityTopology(rows VoltRows) (hashinator, *map[int][]*no
 	var hnator hashinator
 	var err error
 	switch hashType.(string) {
-	case ELASTIC:
-		configFormat := JSON_FORMAT
+	case Elastic:
+		configFormat := JSONFormat
 		cooked := true // json format is by default cooked
 		if hnator, err = newHashinatorElastic(configFormat, cooked, hashConfig.([]byte)); err != nil {
 			return nil, nil, err
@@ -81,7 +81,7 @@ func (c *Conn) updateAffinityTopology(rows VoltRows) (hashinator, *map[int][]*no
 	//First table contains the description of partition ids master/slave relationships
 	rows.AdvanceToTable(0)
 
-	// The MPI's partition ID is 16383 (MpInitiator.MP_INIT_PID), so we shouldn't inadvertently
+	// The MPI's partition ID is 16383 (MpInitiator.MPInitPID), so we shouldn't inadvertently
 	// hash to it.  Go ahead and include it in the maps, we can use it at some point to
 	// route MP transactions directly to the MPI node.
 
@@ -94,7 +94,7 @@ func (c *Conn) updateAffinityTopology(rows VoltRows) (hashinator, *map[int][]*no
 		sites, sitesErr := rows.GetString(1)
 		panicIfnotNil("Error get sites ", sitesErr)
 
-		connections := make([]*nodeConn, 0)
+		var connections []*nodeConn
 		for _, site := range strings.Split(sites.(string), ",") {
 			site = strings.TrimSpace(site)
 			////hostId, hostIdErr := strconv.Atoi(strings.Split(site, ":")[0])
@@ -143,10 +143,10 @@ func (c *Conn) getConnByCA(nodeConns []*nodeConn, hnator hashinator, partitionMa
 	backpressure = true
 
 	// Check if the master for the partition is known.
-	var hashedPartition int = -1
+	var hashedPartition = -1
 
 	if procedureInfo, ok := (*procedureInfos)[pi.query]; ok {
-		hashedPartition = MP_INIT_PID
+		hashedPartition = MPInitPID
 		// User may have passed too few parameters to allow dispatching.
 		if procedureInfo.SinglePartition && procedureInfo.PartitionParameter < pi.getPassedParamCount() {
 			if hashedPartition, err = hnator.getHashedPartitionForParameter(procedureInfo.PartitionParameterType,
@@ -177,7 +177,7 @@ func (c *Conn) getConnByCA(nodeConns []*nodeConn, hnator hashinator, partitionMa
 		} else {
 			// Writes and Safe Reads have to go to the master
 			cxn = (*partitionMasters)[hashedPartition]
-			if (cxn != nil && !cxn.hasBP()) {
+			if cxn != nil && !cxn.hasBP() {
 				backpressure = false
 			}
 		}
@@ -186,4 +186,3 @@ func (c *Conn) getConnByCA(nodeConns []*nodeConn, hnator hashinator, partitionMa
 	// TODO Update clientAffinityStats
 	return
 }
-

--- a/voltdbclient/client_affinity.go
+++ b/voltdbclient/client_affinity.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"math/rand"
-	"strings"
 )
 
 func (c *Conn) subscribeTopo(nc *nodeConn) <-chan voltResponse {
@@ -91,18 +90,18 @@ func (c *Conn) updateAffinityTopology(rows VoltRows) (hashinator, *map[int][]*no
 		partition, partitionErr := rows.GetInteger(0)
 		panicIfnotNil("Error get partition ", partitionErr)
 		// sites, sitesErr := rows.GetStringByName("Sites")
-		sites, sitesErr := rows.GetString(1)
+		_, sitesErr := rows.GetString(1) //sites, sitesErr := rows.GetString(1)
 		panicIfnotNil("Error get sites ", sitesErr)
 
 		var connections []*nodeConn
-		for _, site := range strings.Split(sites.(string), ",") {
-			site = strings.TrimSpace(site)
-			////hostId, hostIdErr := strconv.Atoi(strings.Split(site, ":")[0])
-			//panicIfnotNil("Error get hostId", hostIdErr)
-			//if _, ok := c.hostIdToConnection[hostId]; ok {
-			//	connections = append(connections, c.hostIdToConnection[hostId])
-			//}
-		}
+		//for _, site := range strings.Split(sites.(string), ",") {
+		//site = strings.TrimSpace(site)
+		////hostId, hostIdErr := strconv.Atoi(strings.Split(site, ":")[0])
+		//panicIfnotNil("Error get hostId", hostIdErr)
+		//if _, ok := c.hostIdToConnection[hostId]; ok {
+		//	connections = append(connections, c.hostIdToConnection[hostId])
+		//}
+		//}
 		partitionReplicas[int(partition.(int32))] = connections
 
 		// leaderHost, leaderHostErr := rows.GetStringByName("Leader")

--- a/voltdbclient/client_affinity.go
+++ b/voltdbclient/client_affinity.go
@@ -53,7 +53,8 @@ func (c *Conn) updateAffinityTopology(rows VoltRows) (hashinator, *map[int][]*no
 	}
 
 	if !rows.AdvanceTable() {
-		// Just in case the new client connects to the old version of Volt that only returns 1 topology table
+		// Just in case the new client connects to the old version of Volt that only
+		// returns 1 topology table
 		return nil, nil, errors.New("Not support Legacy hashinator.")
 	} else if !rows.AdvanceRow() { //Second table contains the hash function
 		return nil, nil, errors.New("Topology description received from Volt was incomplete " +
@@ -77,12 +78,13 @@ func (c *Conn) updateAffinityTopology(rows VoltRows) (hashinator, *map[int][]*no
 	}
 	partitionReplicas := make(map[int][]*nodeConn)
 
-	//First table contains the description of partition ids master/slave relationships
+	// First table contains the description of partition ids master/slave
+	// relationships
 	rows.AdvanceToTable(0)
 
-	// The MPI's partition ID is 16383 (MpInitiator.MPInitPID), so we shouldn't inadvertently
-	// hash to it.  Go ahead and include it in the maps, we can use it at some point to
-	// route MP transactions directly to the MPI node.
+	// The MPI's partition ID is 16383 (MpInitiator.MPInitPID), so we shouldn't
+	// inadvertently hash to it. Go ahead and include it in the maps, we can use
+	// it at some point to route MP transactions directly to the MPI node.
 
 	// TODO GetXXXBYName seems broken
 	for rows.AdvanceRow() {

--- a/voltdbclient/client_test.go
+++ b/voltdbclient/client_test.go
@@ -18,16 +18,14 @@
 package voltdbclient
 
 import (
-	"bytes"
-	"database/sql/driver"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"strings"
 	"testing"
 	"time"
 )
 
+/* TODO: fix CallOnClosedConn
 func CallOnClosedConn(t *testing.T) {
 	conn := newNodeConn("", nil)
 	pi := newSyncProcedureInvocation(0, true, "HELLOWORLD.select", []driver.Value{}, time.Minute*2)
@@ -36,7 +34,9 @@ func CallOnClosedConn(t *testing.T) {
 		t.Errorf("Expected error calling procedure on closed Conn")
 	}
 }
+*/
 
+/* TODO: fix ReadDataTypes
 func ReadDataTypes(t *testing.T) {
 	b, err := ioutil.ReadFile("./test_resources/examples_of_types.msg")
 	check(t, err)
@@ -69,8 +69,8 @@ func ReadDataTypes(t *testing.T) {
 		t.Logf("Didn't see expected row")
 		t.FailNow()
 	}
-	iId, err := vrows.GetInteger(0)
-	id := iId.(int32)
+	iID, err := vrows.GetInteger(0)
+	id := iID.(int32)
 	check(t, err)
 	checkRows(t, vrows, id)
 
@@ -78,8 +78,8 @@ func ReadDataTypes(t *testing.T) {
 		t.Logf("Didn't see expected row")
 		t.FailNow()
 	}
-	iId, err = vrows.GetInteger(0)
-	id = iId.(int32)
+	iID, err = vrows.GetInteger(0)
+	id = iID.(int32)
 	check(t, err)
 	checkRows(t, vrows, id)
 
@@ -87,8 +87,8 @@ func ReadDataTypes(t *testing.T) {
 		t.Logf("Didn't see expected row")
 		t.FailNow()
 	}
-	iId, err = vrows.GetInteger(0)
-	id = iId.(int32)
+	iID, err = vrows.GetInteger(0)
+	id = iID.(int32)
 	check(t, err)
 	checkRows(t, vrows, id)
 
@@ -97,6 +97,7 @@ func ReadDataTypes(t *testing.T) {
 		t.FailNow()
 	}
 }
+*/
 
 func checkRows(t *testing.T, rows VoltRows, id int32) {
 	if id == 25 {
@@ -113,29 +114,29 @@ func checkRows(t *testing.T, rows VoltRows, id int32) {
 	}
 }
 
-func checkRowData(t *testing.T, rows VoltRows, expectedId int32, nIdIsNull bool, expectedNId int32,
+func checkRowData(t *testing.T, rows VoltRows, expectedID int32, nIDIsNull bool, expectedNID int32,
 	nameIsNull bool, expectedName string, dataIsNull bool, expectedPrefix string, expectedDataLen int,
 	statusIsNull bool, expectedStatus int8, typeIsNull bool, expectedType int16, panIsNull bool, expectedPan int64,
 	boIsNull bool, expectedBo float64, balanceIsNull bool, expectedBalance float64,
 	lastUpdatedIsNull bool, expectedLastUpdated string) {
 	// ID
-	iId, err := rows.GetIntegerByName("ID")
+	iID, err := rows.GetIntegerByName("ID")
 	check(t, err)
-	id := iId.(int32)
-	if expectedId != id {
-		t.Error(fmt.Printf("For ID, expected %d but saw %d\n", expectedId, id))
+	id := iID.(int32)
+	if expectedID != id {
+		t.Error(fmt.Printf("For ID, expected %d but saw %d\n", expectedID, id))
 	}
 
 	// NULLABLE_ID
-	iNid, err := rows.GetIntegerByName("NULLABLE_ID")
+	iNID, err := rows.GetIntegerByName("NULLABLE_ID")
 	check(t, err)
-	if iNid != nil {
-		nId := iNid.(int32)
-		if nIdIsNull || expectedNId != nId {
-			t.Error(fmt.Printf("For NULLABLE_ID, expected value %d", expectedNId))
+	if iNID != nil {
+		nID := iNID.(int32)
+		if nIDIsNull || expectedNID != nID {
+			t.Error(fmt.Printf("For NULLABLE_ID, expected value %d", expectedNID))
 		}
 	} else {
-		if !nIdIsNull {
+		if !nIDIsNull {
 			t.Error("Unexpected null value for NULLABLE_ID\n")
 		}
 	}

--- a/voltdbclient/constants.go
+++ b/voltdbclient/constants.go
@@ -19,26 +19,28 @@ package voltdbclient
 
 import "math"
 
+// Handles
 const (
-	PING_HANDLE       = math.MaxInt64
-	ASYNC_TOPO_HANDLE = PING_HANDLE - 1
+	PingHandle      = math.MaxInt64
+	AsyncTopoHandle = PingHandle - 1
 )
 
+// Partitions
 const (
-	PARTITIONID_BITS = 14
+	PartitionIDBits = 14
 
 	// maximum values for the txn id fields
-	PARTITIONID_MAX_VALUE = (1 << PARTITIONID_BITS) - 1
-	MP_INIT_PID           = PARTITIONID_MAX_VALUE
+	PartitionIDMaxValue = (1 << PartitionIDBits) - 1
+	MPInitPID           = PartitionIDMaxValue
 )
 
 // Hash Type
 const (
-	ELASTIC = "ELASTIC"
+	Elastic = "Elastic"
 )
 
 // Hash Config Format
 const (
-	BINARAY_FORMAT = 0
-	JSON_FORMAT    = 1
+	BinArrayFormat = 0
+	JSONFormat     = 1
 )

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -307,8 +307,9 @@ func (c *Conn) Close() error {
 }
 
 // Drain blocks until all outstanding asynchronous requests have been satisfied.
-// Asynchronous requests are processed in a background thread; this call blocks the
-// current thread until that background thread has finished with all asynchronous requests.
+// Asynchronous requests are processed in a background thread; this call blocks
+// the current thread until that background thread has finished with all
+// asynchronous requests.
 func (c *Conn) Drain() {
 	drainRespCh := make(chan bool, 1)
 	c.drainCh <- drainRespCh

--- a/voltdbclient/driver.go
+++ b/voltdbclient/driver.go
@@ -22,11 +22,11 @@ import (
 	"database/sql/driver"
 )
 
-// A database/sql/driver for VoltDB.  This driver is registered as 'voltdb'
+// VoltDriver implements A database/sql/driver for VoltDB.  This driver is registered as 'voltdb'
 type VoltDriver struct {
 }
 
-// News an instance of a VoltDB driver.
+// NewVoltDriver returns a new instance of a VoltDB driver.
 func NewVoltDriver() *VoltDriver {
 	var vd = new(VoltDriver)
 	return vd

--- a/voltdbclient/driver.go
+++ b/voltdbclient/driver.go
@@ -23,8 +23,7 @@ import (
 )
 
 // VoltDriver implements A database/sql/driver for VoltDB.  This driver is registered as 'voltdb'
-type VoltDriver struct {
-}
+type VoltDriver struct{}
 
 // NewVoltDriver returns a new instance of a VoltDB driver.
 func NewVoltDriver() *VoltDriver {

--- a/voltdbclient/driver.go
+++ b/voltdbclient/driver.go
@@ -22,7 +22,8 @@ import (
 	"database/sql/driver"
 )
 
-// VoltDriver implements A database/sql/driver for VoltDB.  This driver is registered as 'voltdb'
+// VoltDriver implements A database/sql/driver for VoltDB.  This driver is
+// registered as 'voltdb'
 type VoltDriver struct{}
 
 // NewVoltDriver returns a new instance of a VoltDB driver.

--- a/voltdbclient/fastserializer_test.go
+++ b/voltdbclient/fastserializer_test.go
@@ -175,7 +175,7 @@ func TestReflection(t *testing.T) {
 	var expInt8 int8 = 5
 	marshallParam(&b, expInt8)
 	rVtByte, _ := readByte(&b) // volttype
-	if rVtByte != VT_BOOL {
+	if rVtByte != VTBool {
 		t.Errorf("reflect failed to write volttype byte")
 	}
 	result, _ := readByte(&b)
@@ -184,10 +184,10 @@ func TestReflection(t *testing.T) {
 	}
 
 	b.Reset()
-	var expString string = "abcde"
+	var expString = "abcde"
 	marshallParam(&b, expString)
 	rVtString, _ := readByte(&b) // volttype
-	if rVtString != VT_STRING {
+	if rVtString != VTString {
 		t.Errorf("reflect failed to write volttype string")
 	}
 	rString, _ := readString(&b)
@@ -196,10 +196,10 @@ func TestReflection(t *testing.T) {
 	}
 
 	b.Reset()
-	var expTimestamp time.Time = time.Now().Round(time.Microsecond)
+	var expTimestamp = time.Now().Round(time.Microsecond)
 	marshallParam(&b, expTimestamp)
 	rVtTimestamp, _ := readByte(&b) // volttype
-	if rVtTimestamp != VT_TIMESTAMP {
+	if rVtTimestamp != VTTimestamp {
 		t.Errorf("reflect failed to write volttype timestamp")
 	}
 	rTimestamp, _ := readTimestamp(&b)

--- a/voltdbclient/hashinator.go
+++ b/voltdbclient/hashinator.go
@@ -21,9 +21,8 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"encoding/json"
-	"strconv"
-
 	"errors"
+	"strconv"
 
 	"github.com/spaolacci/murmur3"
 )
@@ -44,7 +43,7 @@ type hashinatorElastic struct {
 }
 
 func newHashinatorElastic(hashConfigFormat int, cooked bool, hashConfig []byte) (h *hashinatorElastic, err error) {
-	if hashConfigFormat != JSON_FORMAT {
+	if hashConfigFormat != JSONFormat {
 		return nil, errors.New("Only support JSON format hashconfig.")
 	}
 	h = new(hashinatorElastic)
@@ -64,7 +63,7 @@ func newHashinatorElastic(hashConfigFormat int, cooked bool, hashConfig []byte) 
 }
 
 func (h *hashinatorElastic) getConfigurationType() string {
-	return ELASTIC
+	return Elastic
 }
 
 func (h *hashinatorElastic) getHashedPartitionForParameter(partitionParameterType int, partitionValue driver.Value) (hashedPartition int, err error) {

--- a/voltdbclient/hashinator_test.go
+++ b/voltdbclient/hashinator_test.go
@@ -15,8 +15,8 @@ var h hashinator
 func BenchmarkHashinater_getHashedPartitionForParameter_int32(b *testing.B) {
 	var hashedPartition int
 	jsonBytes, _ := ioutil.ReadFile("./test_resources/jsonConfigC.bin")
-	h, _ := newHashinatorElastic(JSON_FORMAT, true, jsonBytes)
-	partitionParameterType := int(VT_INT)
+	h, _ := newHashinatorElastic(JSONFormat, true, jsonBytes)
+	partitionParameterType := int(VTInt)
 	partitionValue := driver.Value(r.Int31())
 	b.ResetTimer()
 
@@ -29,8 +29,8 @@ func BenchmarkHashinater_getHashedPartitionForParameter_int32(b *testing.B) {
 func BenchmarkHashinater_getHashedPartitionForParameter_int64(b *testing.B) {
 	var hashedPartition int
 	jsonBytes, _ := ioutil.ReadFile("./test_resources/jsonConfigC.bin")
-	h, _ := newHashinatorElastic(JSON_FORMAT, true, jsonBytes)
-	partitionParameterType := int(VT_LONG)
+	h, _ := newHashinatorElastic(JSONFormat, true, jsonBytes)
+	partitionParameterType := int(VTLong)
 	partitionValue := driver.Value(r.Int63())
 	b.ResetTimer()
 
@@ -43,8 +43,8 @@ func BenchmarkHashinater_getHashedPartitionForParameter_int64(b *testing.B) {
 func BenchmarkHashinater_getHashedPartitionForParameter_String(b *testing.B) {
 	var hashedPartition int
 	jsonBytes, _ := ioutil.ReadFile("./test_resources/jsonConfigC.bin")
-	h, _ := newHashinatorElastic(JSON_FORMAT, true, jsonBytes)
-	partitionParameterType := int(VT_STRING)
+	h, _ := newHashinatorElastic(JSONFormat, true, jsonBytes)
+	partitionParameterType := int(VTString)
 	partitionValue := driver.Value("123456789012345")
 	b.ResetTimer()
 
@@ -57,10 +57,10 @@ func BenchmarkHashinater_getHashedPartitionForParameter_String(b *testing.B) {
 func BenchmarkHashinater_getHashedPartitionForParameter_Bytes(b *testing.B) {
 	var hashedPartition int
 	jsonBytes, _ := ioutil.ReadFile("./test_resources/jsonConfigC.bin")
-	h, _ := newHashinatorElastic(JSON_FORMAT, true, jsonBytes)
+	h, _ := newHashinatorElastic(JSONFormat, true, jsonBytes)
 	valueToHash := make([]byte, 1000)
 	_, _ = rand.Read(valueToHash)
-	partitionParameterType := int(VT_VARBIN)
+	partitionParameterType := int(VTVarBin)
 	partitionValue := driver.Value(valueToHash)
 	b.ResetTimer()
 

--- a/voltdbclient/latency_limiter.go
+++ b/voltdbclient/latency_limiter.go
@@ -36,9 +36,10 @@ type rateLimiter interface {
 	responseReceived(int32)
 }
 
-// latency limiter limits the number of outstanding transactions based on a desired latency.
-// outstanding transactions are transactions that have been sent to the server and for which
-// no response has been received.
+// latency limiter limits the number of outstanding transactions based on a
+// desired latency.
+// Outstanding transactions are transactions that have been sent to the server
+// and for which no response has been received.
 type latencyLimiter struct {
 	blockStart time.Time
 	maxOutTxns int
@@ -109,7 +110,8 @@ func (ll *latencyLimiter) nextBlock() bool {
 }
 
 func (ll *latencyLimiter) calcLatency() {
-	// if there weren't any transactions then have no input about latency, do nothing.
+	// if there weren't any transactions then have no input about latency,
+	// do nothing.
 	if ll.latencyTxns == 0 {
 		return
 	}

--- a/voltdbclient/latency_limiter.go
+++ b/voltdbclient/latency_limiter.go
@@ -25,8 +25,10 @@ import (
 )
 
 const (
-	BLOCK_DURATION = time.Millisecond * 100
-	OUT_TXNS_LIMIT = 20 // as many outstanding transactions as we ever want.
+	// BlockDuration ...
+	BlockDuration = time.Millisecond * 100
+	// OutTXNsLimit defines the amount of outstanding transactions we'd allow.
+	OutTXNsLimit = 20 // as many outstanding transactions as we ever want.
 )
 
 type rateLimiter interface {
@@ -53,7 +55,7 @@ type latencyLimiter struct {
 func newLatencyLimiter(latencyTarget int32) *latencyLimiter {
 	var ll = new(latencyLimiter)
 	ll.blockStart = time.Now()
-	ll.maxOutTxns = OUT_TXNS_LIMIT
+	ll.maxOutTxns = OutTXNsLimit
 	ll.outTxns = 0
 	ll.latencyTarget = latencyTarget
 	return ll
@@ -98,9 +100,9 @@ func (ll *latencyLimiter) getPermit() bool {
 }
 
 func (ll *latencyLimiter) nextBlock() bool {
-	var nextBlock bool = false
-	for time.Since(ll.blockStart).Nanoseconds() > BLOCK_DURATION.Nanoseconds() {
-		ll.blockStart = ll.blockStart.Add(BLOCK_DURATION)
+	var nextBlock bool
+	for time.Since(ll.blockStart).Nanoseconds() > BlockDuration.Nanoseconds() {
+		ll.blockStart = ll.blockStart.Add(BlockDuration)
 		nextBlock = true
 	}
 	return nextBlock
@@ -118,10 +120,10 @@ func (ll *latencyLimiter) calcLatency() {
 			ll.maxOutTxns = 1
 		}
 	} else {
-		if ll.maxOutTxns < OUT_TXNS_LIMIT {
+		if ll.maxOutTxns < OutTXNsLimit {
 			ll.maxOutTxns = int(math.Ceil(float64(ll.maxOutTxns) * 1.1))
-			if ll.maxOutTxns > OUT_TXNS_LIMIT {
-				ll.maxOutTxns = OUT_TXNS_LIMIT
+			if ll.maxOutTxns > OutTXNsLimit {
+				ll.maxOutTxns = OutTXNsLimit
 			}
 		}
 	}

--- a/voltdbclient/procedure_invocation.go
+++ b/voltdbclient/procedure_invocation.go
@@ -82,7 +82,8 @@ func (pi *procedureInvocation) getLen() int {
 }
 
 func (pi *procedureInvocation) calcLen() int {
-	// fixed - 1 for batch timeout type, 4 for str length (proc name), 8 for handle, 2 for paramCount
+	// fixed - 1 for batch timeout type, 4 for str length (proc name),
+	// 8 for handle, 2 for paramCount
 	var slen = 15
 	slen += len(pi.query)
 	for _, param := range pi.params {

--- a/voltdbclient/procedure_invocation.go
+++ b/voltdbclient/procedure_invocation.go
@@ -25,53 +25,53 @@ import (
 )
 
 type procedureInvocation struct {
-	handle  int64
-	isQuery bool // as opposed to an exec.
-	query   string
-	params  []driver.Value
+	handle     int64
+	isQuery    bool // as opposed to an exec.
+	query      string
+	params     []driver.Value
 	responseCh chan voltResponse
-	timeout time.Duration
-	arc   AsyncResponseConsumer
-	async bool
-	slen    int // length of pi once serialized
+	timeout    time.Duration
+	arc        AsyncResponseConsumer
+	async      bool
+	slen       int // length of pi once serialized
 }
 
 func newSyncProcedureInvocation(handle int64, isQuery bool, query string, params []driver.Value, responseCh chan voltResponse, timeout time.Duration) *procedureInvocation {
-	var pi = new(procedureInvocation)
-	pi.handle = handle
-	pi.isQuery = isQuery
-	pi.query = query
-	pi.params = params
-	pi.responseCh = responseCh
-	pi.timeout = timeout
-	pi.async = false
-	pi.slen = -1
-	return pi
+	return &procedureInvocation{
+		handle:     handle,
+		isQuery:    isQuery,
+		query:      query,
+		params:     params,
+		responseCh: responseCh,
+		timeout:    timeout,
+		async:      false,
+		slen:       -1,
+	}
 }
 
 func newAsyncProcedureInvocation(handle int64, isQuery bool, query string, params []driver.Value, timeout time.Duration, arc AsyncResponseConsumer) *procedureInvocation {
-	var pi = new(procedureInvocation)
-	pi.handle = handle
-	pi.isQuery = isQuery
-	pi.query = query
-	pi.params = params
-	pi.timeout = timeout
-	pi.arc = arc
-	pi.async = true
-	pi.slen = -1
-	return pi
+	return &procedureInvocation{
+		handle:  handle,
+		isQuery: isQuery,
+		query:   query,
+		params:  params,
+		timeout: timeout,
+		arc:     arc,
+		async:   true,
+		slen:    -1,
+	}
 }
 
 // a procedure invocation that will be processed based on its handle.
 func newProcedureInvocationByHandle(handle int64, isQuery bool, query string, params []driver.Value) *procedureInvocation {
-	var pi = new(procedureInvocation)
-	pi.handle = handle
-	pi.isQuery = isQuery
-	pi.query = query
-	pi.params = params
-	pi.async = true
-	pi.slen = -1
-	return pi
+	return &procedureInvocation{
+		handle:  handle,
+		isQuery: isQuery,
+		query:   query,
+		params:  params,
+		async:   true,
+		slen:    -1,
+	}
 }
 
 func (pi *procedureInvocation) getLen() int {
@@ -83,7 +83,7 @@ func (pi *procedureInvocation) getLen() int {
 
 func (pi *procedureInvocation) calcLen() int {
 	// fixed - 1 for batch timeout type, 4 for str length (proc name), 8 for handle, 2 for paramCount
-	var slen int = 15
+	var slen = 15
 	slen += len(pi.query)
 	for _, param := range pi.params {
 		slen += pi.calcParamLen(param)
@@ -118,9 +118,8 @@ func (pi *procedureInvocation) calcParamLen(param interface{}) int {
 	case reflect.Struct:
 		if _, ok := v.Interface().(time.Time); ok {
 			return 9
-		} else {
-			panic("Can't determine length of struct")
 		}
+		panic("Can't determine length of struct")
 
 	case reflect.Ptr:
 		panic("Can't marshal a pointer")

--- a/voltdbclient/query_api.go
+++ b/voltdbclient/query_api.go
@@ -24,15 +24,16 @@ import (
 )
 
 // Exec executes a query that doesn't return rows, such as an INSERT or UPDATE.
-// Exec is available on both VoltConn and on VoltStatement.  Uses DEFAULT_QUERY_TIMEOUT.
+// Exec is available on both VoltConn and on VoltStatement.
+// Uses DefaultQueryTimeout.
 func (c *Conn) Exec(query string, args []driver.Value) (driver.Result, error) {
-	return c.ExecTimeout(query, args, DEFAULT_QUERY_TIMEOUT)
+	return c.ExecTimeout(query, args, DefaultQueryTimeout)
 }
 
-// Exec executes a query that doesn't return rows, such as an INSERT or UPDATE.
-// Exec is available on both VoltConn and on VoltStatement.  Specifies a duration for timeout.
+// ExecTimeout executes a query that doesn't return rows, such as an INSERT or
+// UPDATE. ExecTimeout is available on both VoltConn and on VoltStatement.
+// Specifies a duration for timeout.
 func (c *Conn) ExecTimeout(query string, args []driver.Value, timeout time.Duration) (driver.Result, error) {
-
 	responseCh := make(chan voltResponse, 1)
 	pi := newSyncProcedureInvocation(c.getNextHandle(), false, query, args, responseCh, timeout)
 	c.inPiCh <- pi
@@ -48,20 +49,18 @@ func (c *Conn) ExecTimeout(query string, args []driver.Value, timeout time.Durat
 			panic("unexpected response type")
 		}
 	case <-time.After(pi.timeout):
-		return nil, VoltError{voltResponse: voltResponseInfo{status: CONNECTION_TIMEOUT, clusterRoundTripTime: -1}, error: errors.New("timeout")}
+		return nil, VoltError{voltResponse: voltResponseInfo{status: ConnectionTimeout, clusterRoundTripTime: -1}, error: errors.New("timeout")}
 	}
 }
 
-// Exec executes a query that doesn't return rows, such as an INSERT or UPDATE.
 // ExecAsync is analogous to Exec but is run asynchronously.  That is, an
 // invocation of this method blocks only until a request is sent to the VoltDB
-// server.  Uses DEFAULT_QUERY_TIMEOUT.
+// server.  Uses DefaultQueryTimeout.
 func (c *Conn) ExecAsync(resCons AsyncResponseConsumer, query string, args []driver.Value) {
-	c.ExecAsyncTimeout(resCons, query, args, DEFAULT_QUERY_TIMEOUT)
+	c.ExecAsyncTimeout(resCons, query, args, DefaultQueryTimeout)
 }
 
-// Exec executes a query that doesn't return rows, such as an INSERT or UPDATE.
-// ExecAsync is analogous to Exec but is run asynchronously.  That is, an
+// ExecAsyncTimeout is analogous to Exec but is run asynchronously.  That is, an
 // invocation of this method blocks only until a request is sent to the VoltDB
 // server.  Specifies a duration for timeout.
 func (c *Conn) ExecAsyncTimeout(resCons AsyncResponseConsumer, query string, args []driver.Value, timeout time.Duration) {
@@ -76,13 +75,15 @@ func (c *Conn) Prepare(query string) (driver.Stmt, error) {
 	return *stmt, nil
 }
 
-// Query executes a query that returns rows, typically a SELECT. The args are for any placeholder parameters in the query.
-// Uses DEFAULT_QUERY_TIMEOUT.
+// Query executes a query that returns rows, typically a SELECT. The args are
+// for any placeholder parameters in the query.
+// Uses DefaultQueryTimeout.
 func (c *Conn) Query(query string, args []driver.Value) (driver.Rows, error) {
-	return c.QueryTimeout(query, args, DEFAULT_QUERY_TIMEOUT)
+	return c.QueryTimeout(query, args, DefaultQueryTimeout)
 }
 
-// Query executes a query that returns rows, typically a SELECT. The args are for any placeholder parameters in the query.
+// QueryTimeout executes a query that returns rows, typically a SELECT. The args
+// are for any placeholder parameters in the query.
 // Specifies a duration for timeout.
 func (c *Conn) QueryTimeout(query string, args []driver.Value, timeout time.Duration) (driver.Rows, error) {
 	responseCh := make(chan voltResponse, 1)
@@ -99,20 +100,20 @@ func (c *Conn) QueryTimeout(query string, args []driver.Value, timeout time.Dura
 			panic("unexpected response type")
 		}
 	case <-time.After(pi.timeout):
-		return nil, VoltError{voltResponse: voltResponseInfo{status: CONNECTION_TIMEOUT, clusterRoundTripTime: -1}, error: errors.New("timeout")}
+		return nil, VoltError{voltResponse: voltResponseInfo{status: ConnectionTimeout, clusterRoundTripTime: -1}, error: errors.New("timeout")}
 	}
 }
 
 // QueryAsync executes a query asynchronously.  The invoking thread will block
 // until the query is sent over the network to the server.  The eventual
 // response will be handled by the given AsyncResponseConsumer, this processing
-// happens in the 'response' thread.  Uses DEFAULT_QUERY_TIMEOUT.
+// happens in the 'response' thread.  Uses DefaultQueryTimeout.
 func (c *Conn) QueryAsync(rowsCons AsyncResponseConsumer, query string, args []driver.Value) {
-	c.QueryAsyncTimeout(rowsCons, query, args, DEFAULT_QUERY_TIMEOUT)
+	c.QueryAsyncTimeout(rowsCons, query, args, DefaultQueryTimeout)
 }
 
-// QueryAsync executes a query asynchronously.  The invoking thread will block
-// until the query is sent over the network to the server.  The eventual
+// QueryAsyncTimeout executes a query asynchronously.  The invoking thread will
+// block until the query is sent over the network to the server.  The eventual
 // response will be handled by the given AsyncResponseConsumer, this processing
 // happens in the 'response' thread.  Specifies a duration for timeout.
 func (c *Conn) QueryAsyncTimeout(rowsCons AsyncResponseConsumer, query string, args []driver.Value, timeout time.Duration) {

--- a/voltdbclient/result.go
+++ b/voltdbclient/result.go
@@ -32,13 +32,14 @@ func newVoltResult(resp voltResponse, rowsAff []int64) *VoltResult {
 	return vr
 }
 
-// Advances to the next table.  Returns false if there isn't a next table.
+// AdvanceTable advances to the next table. Returns false if there isn't a next
+// table.
 func (vr *VoltResult) AdvanceTable() bool {
 	return vr.AdvanceToTable(vr.ti + 1)
 }
 
-// Advances to the table indicated by the index.  Returns false if there is
-// no table at the given index.
+// AdvanceToTable advances to the table indicated by the index. Returns false if
+// there is no table at the given index.
 func (vr *VoltResult) AdvanceToTable(ti int) bool {
 	if ti >= len(vr.rowsAff) || ti < 0 {
 		return false

--- a/voltdbclient/result.go
+++ b/voltdbclient/result.go
@@ -53,8 +53,7 @@ func (vr VoltResult) LastInsertId() (int64, error) {
 	return 0, nil
 }
 
-// RowsAffected returns the number of rows affected by the
-// query.
+// RowsAffected returns the number of rows affected by the query.
 func (vr VoltResult) RowsAffected() (int64, error) {
 	return vr.rowsAff[vr.ti], nil
 }

--- a/voltdbclient/rows.go
+++ b/voltdbclient/rows.go
@@ -82,8 +82,8 @@ func (vr VoltRows) Next(dest []driver.Value) (err error) {
 		return errors.New("No valid table")
 	}
 	if !vr.table().advanceRow() {
-		// the go doc says to set rows closed when 'Next' return false.  we won't do that
-		// because there can be more than one table.
+		// the go doc says to set rows closed when 'Next' return false.  we won't
+		// do that because there can be more than one table.
 		return io.EOF
 	}
 	if vr.table().getColumnCount() != len(dest) {

--- a/voltdbclient/statement.go
+++ b/voltdbclient/statement.go
@@ -55,13 +55,13 @@ func (vs VoltStatement) NumInput() int {
 }
 
 // Exec executes a query that doesn't return rows, such
-// as an INSERT or UPDATE.  Uses DEFAULT_QUERY_TIMEOUT.
+// as an INSERT or UPDATE.  Uses DefaultQueryTimeout.
 func (vs VoltStatement) Exec(args []driver.Value) (driver.Result, error) {
-	return vs.ExecTimeout(args, DEFAULT_QUERY_TIMEOUT)
+	return vs.ExecTimeout(args, DefaultQueryTimeout)
 }
 
-// Exec executes a query that doesn't return rows, such
-// as an INSERT or UPDATE.  Specifies a duration for timeout.
+// ExecTimeout executes a query that doesn't return rows, such as an INSERT or
+// UPDATE.  Specifies a duration for timeout.
 func (vs VoltStatement) ExecTimeout(args []driver.Value, timeout time.Duration) (driver.Result, error) {
 	args = append(args, "")
 	copy(args[1:], args[0:])
@@ -69,12 +69,13 @@ func (vs VoltStatement) ExecTimeout(args []driver.Value, timeout time.Duration) 
 	return vs.d.ExecTimeout("@AdHoc", args, timeout)
 }
 
-// ExecAsync asynchronously runs an Exec.  Uses DEFAULT_QUERY_TIMEOUT.
+// ExecAsync asynchronously runs an Exec.  Uses DefaultQueryTimeout.
 func (vs VoltStatement) ExecAsync(resCons AsyncResponseConsumer, args []driver.Value) error {
-	return vs.ExecAsyncTimeout(resCons, args, DEFAULT_QUERY_TIMEOUT)
+	return vs.ExecAsyncTimeout(resCons, args, DefaultQueryTimeout)
 }
 
-// ExecAsync asynchronously runs an Exec.  Specifies a duration for timeout.
+// ExecAsyncTimeout asynchronously runs an Exec. Specifies a duration for
+// timeout.
 func (vs VoltStatement) ExecAsyncTimeout(resCons AsyncResponseConsumer, args []driver.Value, timeout time.Duration) error {
 	args = append(args, "")
 	copy(args[1:], args[0:])
@@ -83,12 +84,14 @@ func (vs VoltStatement) ExecAsyncTimeout(resCons AsyncResponseConsumer, args []d
 	return nil
 }
 
-// Query executes a query that may return rows, such as a SELECT.  Uses DEFAULT_QUERY_TIMEOUT.
+// Query executes a query that may return rows, such as a SELECT. Uses
+// DefaultQueryTimeout.
 func (vs VoltStatement) Query(args []driver.Value) (driver.Rows, error) {
-	return vs.QueryTimeout(args, DEFAULT_QUERY_TIMEOUT)
+	return vs.QueryTimeout(args, DefaultQueryTimeout)
 }
 
-// Query executes a query that may return rows, such as a SELECT.  Specifies a duration for timeout.
+// QueryTimeout executes a query that may return rows, such as a SELECT.
+// Specifies a duration for timeout.
 func (vs VoltStatement) QueryTimeout(args []driver.Value, timeout time.Duration) (driver.Rows, error) {
 	args = append(args, "")
 	copy(args[1:], args[0:])
@@ -96,12 +99,13 @@ func (vs VoltStatement) QueryTimeout(args []driver.Value, timeout time.Duration)
 	return vs.d.QueryTimeout("@AdHoc", args, timeout)
 }
 
-// QueryAsync asynchronously runs a Query.  Uses DEFAULT_QUERY_TIMEOUT.
+// QueryAsync asynchronously runs a Query.  Uses DefaultQueryTimeout.
 func (vs VoltStatement) QueryAsync(rowsCons AsyncResponseConsumer, args []driver.Value) error {
-	return vs.QueryAsyncTimeout(rowsCons, args, DEFAULT_QUERY_TIMEOUT)
+	return vs.QueryAsyncTimeout(rowsCons, args, DefaultQueryTimeout)
 }
 
-// QueryAsync asynchronously runs a Query.  Specifies a duration for timeout.
+// QueryAsyncTimeout asynchronously runs a Query. Specifies a duration for
+// timeout.
 func (vs VoltStatement) QueryAsyncTimeout(rowsCons AsyncResponseConsumer, args []driver.Value, timeout time.Duration) error {
 	args = append(args, "")
 	copy(args[1:], args[0:])

--- a/voltdbclient/table.go
+++ b/voltdbclient/table.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 )
 
-const invalid_row_index = -1
+const invalidRowIndex = -1
 
 // Table represents a single result set for a stored procedure invocation.
 type voltTable struct {
@@ -50,7 +50,7 @@ func newVoltTable(columnCount int16, columnTypes []int8, columnNames []string, r
 	for ci, cn := range columnNames {
 		vt.cnToCi[cn] = int16(ci)
 	}
-	vt.rowIndex = invalid_row_index
+	vt.rowIndex = invalidRowIndex
 	return vt
 }
 
@@ -75,8 +75,8 @@ func (vt *voltTable) calcOffsets() error {
 	// column count + 1, want starting and ending index for every column
 	offsets := make([]int32, vt.columnCount+1)
 	r := bytes.NewReader(vt.rows[vt.rowIndex])
-	var colIndex int16 = 0
-	var offset int32 = 0
+	var colIndex int16
+	var offset int32
 	offsets[0] = 0
 	for ; colIndex < vt.columnCount; colIndex++ {
 		len, err := vt.colLength(r, offset, vt.columnTypes[colIndex])

--- a/voltdbclient/txn_limiter.go
+++ b/voltdbclient/txn_limiter.go
@@ -47,7 +47,7 @@ func (tl *txnLimiter) limit(timeout time.Duration) error {
 	case tl.txnSems <- empty{}:
 		return nil
 	case <-time.After(timeout):
-		return errors.New("timeout waiting for transaction permit.")
+		return errors.New("timeout waiting for transaction permit")
 	}
 }
 

--- a/voltdbclient/utils.go
+++ b/voltdbclient/utils.go
@@ -25,12 +25,14 @@ import (
 	"sort"
 )
 
-// partitonSlice attaches the methods of sort.Interface to []int64, sorting in increasing order.
+// partitionSlice attaches the methods of sort.Interface to []int64, sorting in
+// increasing order.
 type token2Partition struct {
 	token     int
 	partition int
 }
 
+// Token2PartitionSlice holds a slice of token2Partition structures.
 type Token2PartitionSlice []token2Partition
 
 func (s Token2PartitionSlice) Len() int           { return len(s) }
@@ -42,6 +44,7 @@ func (s Token2PartitionSlice) Sort() {
 	sort.Sort(s)
 }
 
+// SearchToken2Partitions searches the needed partition by token.
 func SearchToken2Partitions(a []token2Partition, token int) (partition int) {
 	t := sort.Search(len(a), func(i int) bool { return a[i].token >= token })
 	partition = a[t-1].partition

--- a/voltdbclient/voltserializer.go
+++ b/voltdbclient/voltserializer.go
@@ -31,18 +31,18 @@ import (
 
 // The set of VoltDB column types and their associated golang type.
 const (
-	VT_ARRAY     int8 = -99 // array (short)(values*)
-	VT_NULL      int8 = 1   // null
-	VT_BOOL      int8 = 3   // boolean, byte
-	VT_SHORT     int8 = 4   // int16
-	VT_INT       int8 = 5   // int32
-	VT_LONG      int8 = 6   // int64
-	VT_FLOAT     int8 = 8   // float64
-	VT_STRING    int8 = 9   // string (int32-length-prefix)(utf-8 bytes)
-	VT_TIMESTAMP int8 = 11  // int64 timestamp microseconds
-	VT_TABLE     int8 = 21  // VoltTable
-	VT_DECIMAL   int8 = 22  // fix-scaled, fix-precision decimal
-	VT_VARBIN    int8 = 25  // varbinary (int)(bytes)
+	VTArray     int8 = -99 // array (short)(values*)
+	VTNull      int8 = 1   // null
+	VTBool      int8 = 3   // boolean, byte
+	VTShort     int8 = 4   // int16
+	VTInt       int8 = 5   // int32
+	VTLong      int8 = 6   // int64
+	VTFloat     int8 = 8   // float64
+	VTString    int8 = 9   // string (int32-length-prefix)(utf-8 bytes)
+	VTTimestamp int8 = 11  // int64 timestamp microseconds
+	VTTable     int8 = 21  // VoltTable
+	VTDecimal   int8 = 22  // fix-scaled, fix-precision decimal
+	VTVarBin    int8 = 25  // varbinary (int)(bytes)
 )
 
 var order = binary.BigEndian


### PR DESCRIPTION
Code is very heavily influenced by existing code and practices from other languages. The Go community has a very strong preference for idiomatic Go and Go formatting rules. This pull request by use of typical Go linters has been cleaned up to take care of typical issues like:

- incorrect documentation syntax.
- unnecessarily exported types
- unnecessary else conditions (function returns in true condition)
- unnecessarily shadowed variables
- inconsistent line wrapping of comments
- commented out test cases that fail to compile with TODO: annotation to be remembered to fix

Also fixed some tests that had pretty obvious problems.

There will still be plenty of items left but I took care of the most obvious ones.