### PR TITLE
Avoid crash after synchronous query timeout

### DIFF
--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -257,7 +257,7 @@ func (nc *nodeConn) loop(writer io.Writer, piCh <-chan *procedureInvocation, res
 			for _, req := range requests {
 				if time.Now().After(req.submitted.Add(req.timeout)) {
 					queuedBytes -= req.numBytes
-					nc.handleAsyncTimeout(req)
+					nc.handleTimeout(req)
 					delete(requests, req.handle)
 				}
 			}
@@ -318,10 +318,15 @@ func (nc *nodeConn) handleAsyncResponse(handle int64, r io.Reader, req *networkR
 	}
 }
 
-func (nc *nodeConn) handleAsyncTimeout(req *networkRequest) {
+func (nc *nodeConn) handleTimeout(req *networkRequest) {
 	err := errors.New("timeout")
 	verr := VoltError{voltResponse: emptyVoltResponseInfo(), error: err}
-	req.arc.ConsumeError(verr)
+	if req.isSync() {
+		respCh := req.getChan()
+		respCh <- verr
+	} else {
+		req.arc.ConsumeError(verr)
+	}
 }
 
 func (nc *nodeConn) sendPing(writer io.Writer) {


### PR DESCRIPTION
I noticed that if the VoltDB server wasn't available during a synchronous query (I was using `sql.DB`'s  `Query` method), the resulting timeout would panic the process:

```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x570c4f]
 goroutine 19 [running]:
.../github.com/VoltDB/voltdb-client-go/voltdbclient.(*nodeConn).handleAsyncTimeout(0xc42004e3c0, 0xc420067860)
        .../github.com/VoltDB/voltdb-client-go/voltdbclient/node_conn.go:324 +0x19f
.../github.com/VoltDB/voltdb-client-go/voltdbclient.(*nodeConn).loop(0xc42004e3c0, 0x875160, 0xc42000e098, 0xc4200663c0, 0xc420100000, 0xc4200665a0, 0xc420100060)
        .../github.com/VoltDB/voltdb-client-go/voltdbclient/node_conn.go:260 +0x8cb
.../github.com/VoltDB/voltdb-client-go/voltdbclient.(*nodeConn).connect
        .../github.com/VoltDB/voltdb-client-go/voltdbclient/node_conn.go:90 +0x17c
```

From the stacktrace and without digging too much into the surrounding code, it looks like the timeout handler was assuming that only async queries would cause timeouts, so I made it more general, and my problem seems to be solved.