### PR TITLE
ENG-12681: Properly handle results from executing DDL

### DIFF
--- a/voltdbclient/client_test.go
+++ b/voltdbclient/client_test.go
@@ -18,6 +18,7 @@
 package voltdbclient
 
 import (
+	"database/sql"
 	"fmt"
 	"math/big"
 	"strings"
@@ -253,5 +254,44 @@ func checkRowData(t *testing.T, rows VoltRows, expectedID int32, nIDIsNull bool,
 		if !lastUpdatedIsNull {
 			t.Error("Unexpected null value for LAST_UPDATED\n")
 		}
+	}
+}
+
+func TestDDLResult(t *testing.T) {
+
+	// Please comment the following line  to run this test
+	//
+	// This is intentionally skipped as it requires a live voltdb connection to
+	// run. If there is a running voltdb instance you can comment t.Skip() and
+	// adjust the connection string to point to your database instance.
+	t.Skip()
+	db, err := sql.Open("voltdb", "localhost:21212")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := `
+	CREATE TABLE foo(
+		n INTEGER,
+	);
+	`
+	r, err := db.Exec("@AdHoc", s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	last, err := r.LastInsertId()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if last != 0 {
+		t.Errorf("expected 0 got %d", last)
+	}
+	rows, err := r.RowsAffected()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows != 0 {
+		t.Errorf("expected 0 got %d", rows)
 	}
 }

--- a/voltdbclient/response.go
+++ b/voltdbclient/response.go
@@ -303,7 +303,8 @@ func deserializeTableForResult(r io.Reader) (rowsAff int64, err error) {
 	if err != nil {
 		return 0, err
 	}
-	if strings.Compare("modified_tuples", cname) != 0 {
+
+	if strings.Compare("modified_tuples", cname) != 0 && cname != "STATUS" {
 		return 0, errors.New("Expected 'modified_tubles' for column name for result")
 	}
 

--- a/voltdbclient/response.go
+++ b/voltdbclient/response.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"strings"
 )
 
 type voltResponse interface {
@@ -304,8 +303,8 @@ func deserializeTableForResult(r io.Reader) (rowsAff int64, err error) {
 		return 0, err
 	}
 
-	if strings.Compare("modified_tuples", cname) != 0 && cname != "STATUS" {
-		return 0, errors.New("Expected 'modified_tubles' for column name for result")
+	if cname != "modified_tuples" && cname != "STATUS" {
+		return 0, errors.New("Expected 'modified_tubles'  or STATUS  for column name for result")
 	}
 
 	rowCount, err := readInt(r)


### PR DESCRIPTION
Execution of DDL statements  returns a  `STATUS ` column name instead of  `modified_tuples` . The current implementation relied only on checking `modified_tuples` column and raising an error when it doesnt match `modified_tuples`.

This commit takes care of properly handling of results of executing DDL statements such as CREATE TABLE.