### PR TITLE
[WIP] Add new  Encoder Implemenatation

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -3,6 +3,7 @@ package voltdb
 import (
 	"bytes"
 	"encoding/binary"
+	"math"
 )
 
 //size of bytes
@@ -89,4 +90,11 @@ func (e *Encoder) uint64(v uint64) (int, error) {
 	b := make([]byte, longSize)
 	endian.PutUint64(b, v)
 	return e.buf.Write(b)
+}
+
+// Float64 encodes float64 value to voltdb wire protocol float type. This uses
+// math.Float64bits to covert v to uint64 which is encoded into []byte of size
+// 8.  For a successful encoding the number of bytes written is 8
+func (e *Encoder) Float64(v float64) (int, error) {
+	return e.uint64(math.Float64bits(v))
 }

--- a/encoder.go
+++ b/encoder.go
@@ -66,3 +66,15 @@ func (e *Encoder) uint16(v uint16) (int, error) {
 	endian.PutUint16(b, v)
 	return e.buf.Write(b)
 }
+
+// Int32 encodes int32 value to voltdb wire protocol Integer. For a successful
+// encoding the number of bytes written is 4
+func (e *Encoder) Int32(v int32) (int, error) {
+	return e.uint32(uint32(v))
+}
+
+func (e *Encoder) uint32(v uint32) (int, error) {
+	b := make([]byte, integerSize)
+	endian.PutUint32(b, v)
+	return e.buf.Write(b)
+}

--- a/encoder.go
+++ b/encoder.go
@@ -113,3 +113,11 @@ func (e *Encoder) Binary(v []byte) (int, error) {
 	}
 	return s + n, nil
 }
+
+// Bool encodes bool values to voltdb wireprotocol boolean
+func (e *Encoder) Bool(v bool) (int, error) {
+	if v {
+		return e.Byte(0x1)
+	}
+	return e.Byte(0x0)
+}

--- a/encoder.go
+++ b/encoder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"math"
+	"time"
 )
 
 //size of bytes
@@ -127,4 +128,13 @@ func (e *Encoder) Bool(v bool) (int, error) {
 // bytes of the string.
 func (e *Encoder) String(v string) (int, error) {
 	return e.Binary([]byte(v))
+}
+
+// Time encodes time.Time value to voltdb wire protocol time.
+func (e Encoder) Time(v time.Time) (int, error) {
+	nano := v.Round(time.Microsecond).UnixNano()
+	if v.IsZero() {
+		return e.Int64(math.MinInt64)
+	}
+	return e.Int64(nano / int64(time.Microsecond))
 }

--- a/encoder.go
+++ b/encoder.go
@@ -15,7 +15,7 @@ const (
 	longSize    = 8
 )
 
-// We are using big endian t encode the values for voltdb wire protocol
+// We are using big endian to encode the values for voltdb wire protocol
 var endian = binary.BigEndian
 
 // Encoder defines methods for encoding Go values to voltdb wire protocol. This
@@ -42,7 +42,7 @@ func (e *Encoder) Reset() {
 	e.buf.Reset()
 }
 
-// Byte encodes int8 value of voltdb wire protocol Byte. This returns the number
+// Byte encodes int8 value to voltdb wire protocol Byte. This returns the number
 // of bytes written and an error if any.
 //
 // For a successful encoding the value of number of bytes written is 1
@@ -102,7 +102,7 @@ func (e *Encoder) Float64(v float64) (int, error) {
 
 // Binary encodes []byte to voltdb wire protocol varbinary
 //
-// This first encodes the size of v as voltdb Short followed by v as raw bytes.
+// This first encodes the size of v as voltdb Short followed by raw bytes of v.
 func (e *Encoder) Binary(v []byte) (int, error) {
 	s, err := e.Int32(int32(len(v)))
 	if err != nil {

--- a/encoder.go
+++ b/encoder.go
@@ -121,3 +121,10 @@ func (e *Encoder) Bool(v bool) (int, error) {
 	}
 	return e.Byte(0x0)
 }
+
+// String encodes strings to voltdb wire protocol string. A string is treated
+// like []byte. We first encode the size of the string, followed by the raw
+// bytes of the string.
+func (e *Encoder) String(v string) (int, error) {
+	return e.Binary([]byte(v))
+}

--- a/encoder.go
+++ b/encoder.go
@@ -78,3 +78,15 @@ func (e *Encoder) uint32(v uint32) (int, error) {
 	endian.PutUint32(b, v)
 	return e.buf.Write(b)
 }
+
+// Int64 encodes int64 value into voltdb wire protocol Long. For a successful
+// encoding the number of bytes written is 8
+func (e *Encoder) Int64(v int64) (int, error) {
+	return e.uint64(uint64(v))
+}
+
+func (e *Encoder) uint64(v uint64) (int, error) {
+	b := make([]byte, longSize)
+	endian.PutUint64(b, v)
+	return e.buf.Write(b)
+}

--- a/encoder.go
+++ b/encoder.go
@@ -1,0 +1,56 @@
+package voltdb
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+//size of bytes
+const (
+	byteSize    = 1
+	shortSize   = 2
+	integerSize = 4
+	longSize    = 8
+)
+
+// We are using big endian t encode the values for voltdb wire protocol
+var endian = binary.BigEndian
+
+// Encoder defines methods for encoding Go values to voltdb wire protocol. This
+// struct is reusable, you can call Reset method and start encodeing new fresh
+// values.
+//
+// Values are encoded in Big Endian byte order mark.
+//
+// To retrieve []byte of the encoded values use Bytes method.
+type Encoder struct {
+	buf *bytes.Buffer
+}
+
+// NewEncoder returns a new Encoder instance
+func NewEncoder() *Encoder {
+	return &Encoder{buf: &bytes.Buffer{}}
+}
+
+//Reset resets the underlying buffer. This will remove any values that were
+//encoded before.
+//
+//Call this to reuse the Encoder and avoid unnecessary allocations.
+func (e *Encoder) Reset() {
+	e.buf.Reset()
+}
+
+// Byte encodes int8 value of voltdb wire protocol Byte. This returns the number
+// of bytes written and an error if any.
+//
+// For a successful encoding the value of number of bytes written is 1
+func (e *Encoder) Byte(v int8) (int, error) {
+	b := make([]byte, byteSize)
+	b[0] = byte(v)
+	return e.buf.Write(b)
+}
+
+// Bytes returns the buffered voltdb wire protocol encoded bytes
+func (e *Encoder) Bytes() []byte {
+	return e.buf.Bytes()
+}

--- a/encoder.go
+++ b/encoder.go
@@ -54,3 +54,15 @@ func (e *Encoder) Byte(v int8) (int, error) {
 func (e *Encoder) Bytes() []byte {
 	return e.buf.Bytes()
 }
+
+// Int16 encodes int16 value to voltdb wire protocol Short. For a successful
+// encoding the number of bytes written is 2
+func (e *Encoder) Int16(v int16) (int, error) {
+	return e.uint16(uint16(v))
+}
+
+func (e *Encoder) uint16(v uint16) (int, error) {
+	b := make([]byte, shortSize)
+	endian.PutUint16(b, v)
+	return e.buf.Write(b)
+}

--- a/encoder.go
+++ b/encoder.go
@@ -98,3 +98,18 @@ func (e *Encoder) uint64(v uint64) (int, error) {
 func (e *Encoder) Float64(v float64) (int, error) {
 	return e.uint64(math.Float64bits(v))
 }
+
+// Binary encodes []byte to voltdb wire protocol varbinary
+//
+// This first encodes the size of v as voltdb Short followed by v as raw bytes.
+func (e *Encoder) Binary(v []byte) (int, error) {
+	s, err := e.Int32(int32(len(v)))
+	if err != nil {
+		return 0, err
+	}
+	n, err := e.buf.Write(v)
+	if err != nil {
+		return 0, err
+	}
+	return s + n, nil
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,0 +1,37 @@
+package voltdb
+
+import (
+	"testing"
+)
+
+func TestEncoder_Byte(t *testing.T) {
+	t.Parallel()
+
+	var s byte = 0x10
+
+	e := NewEncoder()
+
+	n, err := e.Byte(int8(s))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 got %d", n)
+	}
+	b := e.Bytes()
+	if b[0] != s {
+		t.Error("expected the same byte")
+	}
+
+	sample := []int8{-128, -10, 0, 127}
+	for _, val := range sample {
+		e.Reset()
+		_, err = e.Byte(val)
+		if err != nil {
+			t.Error(err)
+		}
+
+		//TODO(gernest): Add Decoding implementation to verify that the encoded
+		//values are correct.
+	}
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -51,3 +51,19 @@ func TestEncoder_Int16(t *testing.T) {
 	}
 
 }
+
+func TestEncoder_Int32(t *testing.T) {
+	t.Parallel()
+	sample := []int32{-100, -1, 0, 1, 100}
+	e := NewEncoder()
+	for _, v := range sample {
+		e.Reset()
+		n, err := e.Int32(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != integerSize {
+			t.Errorf("expected %d got %d", integerSize, n)
+		}
+	}
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,6 +1,7 @@
 package voltdb
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -82,5 +83,26 @@ func TestEncoder_Float64(t *testing.T) {
 		if n != longSize {
 			t.Errorf("expected %d got %d", longSize, n)
 		}
+	}
+}
+
+func TestEncoder_String(t *testing.T) {
+	expected := []byte{0x00, 0x00, 0x00, 0x06, 'a', 'b', 'c', 'd', 'e', 'f'}
+	s := "abcdef"
+
+	e := NewEncoder()
+
+	n, err := e.String(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := len(s) + integerSize
+	if n != ns {
+		t.Errorf("expected %d got %d", ns, n)
+	}
+
+	b := e.Bytes()
+	if !bytes.Equal(b, expected) {
+		t.Errorf("expected %s got %s", string(expected), string(b))
 	}
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -3,6 +3,7 @@ package voltdb
 import (
 	"bytes"
 	"testing"
+	"time"
 )
 
 func TestEncoder_Byte(t *testing.T) {
@@ -105,4 +106,19 @@ func TestEncoder_String(t *testing.T) {
 	if !bytes.Equal(b, expected) {
 		t.Errorf("expected %s got %s", string(expected), string(b))
 	}
+}
+
+func TestEncoder_Time(t *testing.T) {
+	e := NewEncoder()
+
+	n, err := e.Time(time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != longSize {
+		t.Errorf("expected %d got %d", longSize, n)
+	}
+
+	//TODO(gernest): Add Decoder to verify the encoded values for time are
+	//correct.
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -88,6 +88,7 @@ func TestEncoder_Float64(t *testing.T) {
 }
 
 func TestEncoder_String(t *testing.T) {
+	t.Parallel()
 	expected := []byte{0x00, 0x00, 0x00, 0x06, 'a', 'b', 'c', 'd', 'e', 'f'}
 	s := "abcdef"
 
@@ -109,6 +110,7 @@ func TestEncoder_String(t *testing.T) {
 }
 
 func TestEncoder_Time(t *testing.T) {
+	t.Parallel()
 	e := NewEncoder()
 
 	n, err := e.Time(time.Time{})

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -35,3 +35,19 @@ func TestEncoder_Byte(t *testing.T) {
 		//values are correct.
 	}
 }
+
+func TestEncoder_Int16(t *testing.T) {
+	t.Parallel()
+
+	var s1 int16 = 0x4BCD
+
+	e := NewEncoder()
+	n, err := e.Int16(s1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != shortSize {
+		t.Errorf("expected %d got %d", shortSize, n)
+	}
+
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -67,3 +67,20 @@ func TestEncoder_Int32(t *testing.T) {
 		}
 	}
 }
+
+func TestEncoder_Float64(t *testing.T) {
+	t.Parallel()
+
+	sample := []float64{-100.1, -1.01, 0.0, 1.01, 100.1}
+	e := NewEncoder()
+
+	for _, v := range sample {
+		n, err := e.Float64(v)
+		if err != nil {
+			t.Error(err)
+		}
+		if n != longSize {
+			t.Errorf("expected %d got %d", longSize, n)
+		}
+	}
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -15,8 +15,8 @@ func TestEncoder_Byte(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if n != 1 {
-		t.Errorf("expected 1 got %d", n)
+	if n != byteSize {
+		t.Errorf("expected %d got %d", byteSize, n)
 	}
 	b := e.Bytes()
 	if b[0] != s {


### PR DESCRIPTION
__APOLOGIES__: Please DO NOT MERGE This needs a JIRA ticket to track, unfortunate that ticket doesn't exist yet so I have decided to keep hacking on this while waiting. 

NOTES:

The current encoding/decoding implementation is not visible, making reasoning about the wire protocol a bit hard.

I will use this function taken from the client as an example

```go
func writeShort(w io.Writer, d int16) error {
    ...
}
```

First, the name `writeShort` doesnt say much about what this is up to. It happens `Short` refers to `int16` 
, the function signature too, will not help ease navigation through the code base.

I propose changing the API to something like this

```go
// Int16 encodes int16 value to voltdb wire protocol Short. For a successful
// encoding the number of bytes written is 2
func (e *Encoder) Int16(v int16) (int, error) {
      ...
}
```

Here, we will have very rich API with relevant infromation like
- How many bytes a `int16`/`Short` occupies when encoded
- We can optimize how we store the encoded values either in `[]byte` or any optimal ways without relying on an external `io.Writer`

CAVEATS

The new encoder does not/ will not play well with the current client implementation. Since I will end up rewriting most part of the client this should not be a big issue, I will not refactor the existing client to use the new encoder to avoid wasting of time.