### PR TITLE
Reduce wasteful  SystemCatalog  and Statistics procedure invocation

### DIFF
--- a/voltdbclient/client_affinity.go
+++ b/voltdbclient/client_affinity.go
@@ -24,6 +24,8 @@ import (
 	"math/rand"
 )
 
+var errLegacyHashinator = errors.New("Not support Legacy hashinator.")
+
 func (c *Conn) subscribeTopo(nc *nodeConn) <-chan voltResponse {
 	responseCh := make(chan voltResponse, 1)
 	SubscribeTopoPi := newSyncProcedureInvocation(c.getNextSystemHandle(), true, "@Subscribe", []driver.Value{"TOPOLOGY"}, responseCh, DefaultQueryTimeout)
@@ -55,7 +57,7 @@ func (c *Conn) updateAffinityTopology(rows VoltRows) (hashinator, *map[int][]*no
 	if !rows.AdvanceTable() {
 		// Just in case the new client connects to the old version of Volt that only
 		// returns 1 topology table
-		return nil, nil, errors.New("Not support Legacy hashinator.")
+		return nil, nil, errLegacyHashinator
 	} else if !rows.AdvanceRow() { //Second table contains the hash function
 		return nil, nil, errors.New("Topology description received from Volt was incomplete " +
 			"performance will be lower because transactions can't be routed at this client")

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -250,7 +250,9 @@ func (c *Conn) loop(connected []*nodeConn, disconnected []*nodeConn, hostIDToCon
 					partitionReplicas = tmpPartitionReplicas
 					topoStatsCh = nil
 				} else {
-					hasTopoStats = false
+					if err.Error() != errLegacyHashinator.Error() {
+						hasTopoStats = false
+					}
 				}
 			default:
 				hasTopoStats = false
@@ -259,7 +261,7 @@ func (c *Conn) loop(connected []*nodeConn, disconnected []*nodeConn, hostIDToCon
 			switch prInfoResp.(type) {
 			case VoltRows:
 				tmpProcedureInfos, err := c.updateProcedurePartitioning(prInfoResp.(VoltRows))
-				if err != nil {
+				if err == nil {
 					procedureInfos = tmpProcedureInfos
 					prInfoCh = nil
 				} else {


### PR DESCRIPTION
This commit ensures that we only call  `@SystemCatalog` and `@Statistics` once per `*Conn`