### PR TITLE
ENG-12809: Go driver doesn't read some responses in async mode

### DIFF
--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -189,7 +189,6 @@ func (nc *nodeConn) loop(writer io.Writer, piCh <-chan *procedureInvocation, res
 	var drainRespCh chan bool
 	var queuedBytes int
 	var bp bool
-	decoder := &wire.Decoder{}
 
 	var tci = int64(DefaultQueryTimeout / 10)                    // timeout check interval
 	tcc := time.NewTimer(time.Duration(tci) * time.Nanosecond).C // timeout check timer channel
@@ -260,7 +259,6 @@ func (nc *nodeConn) loop(writer io.Writer, piCh <-chan *procedureInvocation, res
 			queuedBytes -= req.numBytes
 			delete(requests, handle)
 			if req.isSync() {
-				decoder.SetReader(resp)
 
 				nc.handleSyncResponse(handle, resp, req)
 			} else {

--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -32,6 +32,7 @@ import (
 
 // start back pressure when this many bytes are queued for write
 const maxQueuedBytes = 262144
+const maxResponseBuffer = 10000
 
 type nodeConn struct {
 	connInfo string
@@ -75,7 +76,7 @@ func (nc *nodeConn) connect(protocolVersion int, piCh <-chan *procedureInvocatio
 	nc.connData = connData
 	nc.tcpConn = tcpConn
 
-	responseCh := make(chan *bytes.Buffer, 10)
+	responseCh := make(chan *bytes.Buffer, maxResponseBuffer)
 	go nc.listen(tcpConn, responseCh)
 
 	nc.drainCh = make(chan chan bool, 1)
@@ -99,7 +100,7 @@ func (nc *nodeConn) reconnect(protocolVersion int, piCh <-chan *procedureInvocat
 		nc.tcpConn = tcpConn
 		nc.connData = connData
 
-		responseCh := make(chan *bytes.Buffer, 10)
+		responseCh := make(chan *bytes.Buffer, maxResponseBuffer)
 		go nc.listen(tcpConn, responseCh)
 		go nc.loop(tcpConn, piCh, responseCh, nc.bpCh, nc.drainCh)
 		break

--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -264,7 +264,7 @@ func (nc *nodeConn) loop(writer io.Writer, piCh <-chan *procedureInvocation, res
 
 				nc.handleSyncResponse(handle, resp, req)
 			} else {
-				go nc.handleAsyncResponse(handle, resp, req)
+				nc.handleAsyncResponse(handle, resp, req)
 			}
 		case respBPCh := <-bpCh:
 			respBPCh <- bp


### PR DESCRIPTION
After deep investigation, I have come into conclusion that the responses arent processed fast enough resulting into the the response channel to block .

When the response channel is full, the  voltdb instances closes the connection when  responses are not read for a specific timeout limit leading to broken pipe error and connection reset error.

This is  workaround based from observation of the voter benchmark. I was doing increments of multiples of 10 to find the right buffer size.