### PR TITLE
more idiomatic go code and minor bugfix

### DIFF
--- a/voltdbclient/driver.go
+++ b/voltdbclient/driver.go
@@ -28,8 +28,7 @@ type VoltDriver struct{}
 
 // NewVoltDriver returns a new instance of a VoltDB driver.
 func NewVoltDriver() *VoltDriver {
-	var vd = new(VoltDriver)
-	return vd
+	return &VoltDriver{}
 }
 
 // Open a connection to the VoltDB server.

--- a/voltdbclient/hashinator.go
+++ b/voltdbclient/hashinator.go
@@ -54,13 +54,15 @@ func newHashinatorElastic(hashConfigFormat int, cooked bool, hashConfig []byte) 
 	if hashConfigFormat != JSONFormat {
 		return nil, errors.New("Only support JSON format hashconfig.")
 	}
-	h = new(hashinatorElastic)
+
 	if cooked {
 		hashConfig, err = fromGzip(hashConfig)
 		if err != nil {
 			return nil, err
 		}
 	}
+
+	h = &hashinatorElastic{}
 
 	// unmarshall json
 	if err = h.unmarshalJSONConfig(hashConfig); err != nil {

--- a/voltdbclient/latency_limiter.go
+++ b/voltdbclient/latency_limiter.go
@@ -54,12 +54,11 @@ type latencyLimiter struct {
 }
 
 func newLatencyLimiter(latencyTarget int32) *latencyLimiter {
-	var ll = new(latencyLimiter)
-	ll.blockStart = time.Now()
-	ll.maxOutTxns = OutTXNsLimit
-	ll.outTxns = 0
-	ll.latencyTarget = latencyTarget
-	return ll
+	return &latencyLimiter{
+		blockStart:    time.Now(),
+		maxOutTxns:    OutTXNsLimit,
+		latencyTarget: latencyTarget,
+	}
 }
 
 func (ll *latencyLimiter) limit(timeout time.Duration) error {

--- a/voltdbclient/network_request.go
+++ b/voltdbclient/network_request.go
@@ -34,29 +34,29 @@ type networkRequest struct {
 }
 
 func newSyncRequest(handle int64, ch chan voltResponse, isQuery bool, numBytes int, timeout time.Duration, submitted time.Time) *networkRequest {
-	var nr = new(networkRequest)
-	nr.handle = handle
-	nr.query = isQuery
-	nr.ch = ch
-	nr.sync = true
-	nr.arc = nil
-	nr.numBytes = numBytes
-	nr.submitted = submitted
-	nr.timeout = timeout
-	return nr
+	return &networkRequest{
+		handle:    handle,
+		query:     isQuery,
+		ch:        ch,
+		sync:      true,
+		arc:       nil,
+		numBytes:  numBytes,
+		submitted: submitted,
+		timeout:   timeout,
+	}
 }
 
 func newAsyncRequest(handle int64, ch chan voltResponse, isQuery bool, arc AsyncResponseConsumer, numBytes int, timeout time.Duration, submitted time.Time) *networkRequest {
-	var nr = new(networkRequest)
-	nr.handle = handle
-	nr.query = isQuery
-	nr.ch = ch
-	nr.sync = false
-	nr.arc = arc
-	nr.numBytes = numBytes
-	nr.submitted = submitted
-	nr.timeout = timeout
-	return nr
+	return &networkRequest{
+		handle:    handle,
+		query:     isQuery,
+		ch:        ch,
+		sync:      false,
+		arc:       arc,
+		numBytes:  numBytes,
+		submitted: submitted,
+		timeout:   timeout,
+	}
 }
 
 func (nr *networkRequest) getArc() AsyncResponseConsumer {

--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -50,15 +50,15 @@ type nodeConn struct {
 }
 
 func newNodeConn(ci string, ncPiCh chan *procedureInvocation) *nodeConn {
-	var nc = new(nodeConn)
-	nc.connInfo = ci
-	nc.ncPiCh = ncPiCh
-	nc.bpCh = make(chan chan bool)
-	nc.closeCh = make(chan chan bool)
-	nc.drainCh = make(chan chan bool)
-	nc.decoder = wire.NewDecoder(nil)
-	nc.encoder = wire.NewEncoder()
-	return nc
+	return &nodeConn{
+		connInfo: ci,
+		ncPiCh:   ncPiCh,
+		bpCh:     make(chan chan bool),
+		closeCh:  make(chan chan bool),
+		drainCh:  make(chan chan bool),
+		decoder:  wire.NewDecoder(nil),
+		encoder:  wire.NewEncoder(),
+	}
 }
 
 func (nc *nodeConn) submit(pi *procedureInvocation) {
@@ -93,7 +93,6 @@ func (nc *nodeConn) connect(protocolVersion int, piCh <-chan *procedureInvocatio
 // the 'processAsyncs' goroutine and channel stay in place over
 // a reconnect, they're not affected.
 func (nc *nodeConn) reconnect(protocolVersion int, piCh <-chan *procedureInvocation) {
-
 	for {
 		tcpConn, connData, err := nc.networkConnect(protocolVersion)
 		if err != nil {
@@ -162,7 +161,6 @@ func (nc *nodeConn) hasBP() bool {
 // listen listens for messages from the server and calls back a registered listener.
 // listen blocks on input from the server and should be run as a go routine.
 func (nc *nodeConn) listen(reader io.Reader, responseCh chan<- *bytes.Buffer) {
-
 	d := wire.NewDecoder(reader)
 	s := &wire.Decoder{}
 	for {
@@ -190,7 +188,6 @@ func (nc *nodeConn) listen(reader io.Reader, responseCh chan<- *bytes.Buffer) {
 }
 
 func (nc *nodeConn) loop(writer io.Writer, piCh <-chan *procedureInvocation, responseCh <-chan *bytes.Buffer, bpCh <-chan chan bool, drainCh chan chan bool) {
-
 	// declare mutable state
 	requests := make(map[int64]*networkRequest)
 	ncPiCh := nc.ncPiCh

--- a/voltdbclient/response.go
+++ b/voltdbclient/response.go
@@ -53,39 +53,31 @@ type voltResponseInfo struct {
 }
 
 func newVoltResponseInfo(handle int64, status ResponseStatus, statusString string, appStatus ResponseStatus, appStatusString string, clusterRoundTripTime int32, numTables int16) *voltResponseInfo {
-	var vrsp = new(voltResponseInfo)
-	vrsp.handle = handle
-	vrsp.status = status
-	vrsp.statusString = statusString
-	vrsp.appStatus = appStatus
-	vrsp.appStatusString = appStatusString
-	vrsp.clusterRoundTripTime = clusterRoundTripTime
-	vrsp.numTables = numTables
-	return vrsp
+	return &voltResponseInfo{
+		handle:               handle,
+		status:               status,
+		statusString:         statusString,
+		appStatus:            appStatus,
+		appStatusString:      appStatusString,
+		clusterRoundTripTime: clusterRoundTripTime,
+		numTables:            numTables,
+	}
 }
 
 func emptyVoltResponseInfo() voltResponseInfo {
-	var vrsp = new(voltResponseInfo)
-	vrsp.handle = 0
-	vrsp.status = Success
-	vrsp.statusString = ""
-	vrsp.appStatus = UninitializedAppStatusCode
-	vrsp.appStatusString = ""
-	vrsp.clusterRoundTripTime = -1
-	vrsp.numTables = 0
-	return *vrsp
+	return voltResponseInfo{
+		status:               Success,
+		appStatus:            UninitializedAppStatusCode,
+		clusterRoundTripTime: -1,
+	}
 }
 
 func emptyVoltResponseInfoWithLatency(rtt int32) voltResponseInfo {
-	var vrsp = new(voltResponseInfo)
-	vrsp.handle = 0
-	vrsp.status = Success
-	vrsp.statusString = ""
-	vrsp.appStatus = UninitializedAppStatusCode
-	vrsp.appStatusString = ""
-	vrsp.clusterRoundTripTime = rtt
-	vrsp.numTables = 0
-	return *vrsp
+	return voltResponseInfo{
+		status:               Success,
+		appStatus:            UninitializedAppStatusCode,
+		clusterRoundTripTime: rtt,
+	}
 }
 
 func (vrsp voltResponseInfo) getAppStatus() ResponseStatus {
@@ -137,27 +129,28 @@ const (
 
 // Represent a ResponseStatus as a string.
 func (rs ResponseStatus) String() string {
-	if rs == Success {
+	switch rs {
+	case Success:
 		return "SUCCESS"
-	} else if rs == UserAbort {
+	case UserAbort:
 		return "USER ABORT"
-	} else if rs == GracefulFailure {
+	case GracefulFailure:
 		return "GRACEFUL FAILURE"
-	} else if rs == UnexpectedFailure {
+	case UnexpectedFailure:
 		return "UNEXPECTED FAILURE"
-	} else if rs == ConnectionLost {
+	case ConnectionLost:
 		return "CONNECTION LOST"
-	} else if rs == ServerUnavailable {
+	case ServerUnavailable:
 		return "SERVER UNAVAILABLE"
-	} else if rs == ConnectionTimeout {
+	case ConnectionTimeout:
 		return "CONNECTION TIMEOUT"
-	} else if rs == ResponseUnknown {
+	case ResponseUnknown:
 		return "RESPONSE UNKNOWN"
-	} else if rs == TXNRestart {
+	case TXNRestart:
 		return "TXN RESTART"
-	} else if rs == OperationalFailure {
+	case OperationalFailure:
 		return "OPERATIONAL FAILURE"
-	} else if rs == UninitializedAppStatusCode {
+	case UninitializedAppStatusCode:
 		return "UNINITIALIZED APP STATUS CODE"
 	}
 	panic(fmt.Sprintf("Invalid status code: %d", int(rs)))
@@ -281,8 +274,6 @@ func decodeTableCommon(d *wire.Decoder) (colCount int16, err error) {
 }
 
 // for a result, care only about the number of rows.
-
-// for a result, care only about the number of rows.
 func decodeTableForResult(d *wire.Decoder) (rowsAff int64, err error) {
 
 	var colCount int16
@@ -365,13 +356,11 @@ func decodeTableForRows(d *wire.Decoder) (*voltTable, error) {
 	}
 
 	rows := make([][]byte, rowCount)
-	//var offset int64 = 0
 	var rowI int32
 	for rowI = 0; rowI < rowCount; rowI++ {
 		rowLen, _ := d.Int32()
 		rows[rowI] = make([]byte, rowLen)
 		_, _ = d.Read(rows[rowI])
-		//offset += int64(rowLen + 4)
 	}
 
 	return newVoltTable(colCount, columnTypes, columnNames, rowCount, rows), nil

--- a/voltdbclient/result.go
+++ b/voltdbclient/result.go
@@ -25,11 +25,10 @@ type VoltResult struct {
 }
 
 func newVoltResult(resp voltResponse, rowsAff []int64) *VoltResult {
-	var vr = new(VoltResult)
-	vr.voltResponse = resp
-	vr.rowsAff = rowsAff
-	vr.ti = 0
-	return vr
+	return &VoltResult{
+		voltResponse: resp,
+		rowsAff:      rowsAff,
+	}
 }
 
 // AdvanceTable advances to the next table. Returns false if there isn't a next

--- a/voltdbclient/rows.go
+++ b/voltdbclient/rows.go
@@ -51,13 +51,12 @@ type VoltRows struct {
 }
 
 func newVoltRows(resp voltResponse, tables []*voltTable) *VoltRows {
-	var vr = new(VoltRows)
-	vr.voltResponse = resp
-	vr.tables = tables
+	var vr = &VoltRows{
+		voltResponse: resp,
+		tables:       tables,
+	}
 	if len(tables) == 0 {
 		vr.tableIndex = -1
-	} else {
-		vr.tableIndex = 0
 	}
 	return vr
 }

--- a/voltdbclient/statement.go
+++ b/voltdbclient/statement.go
@@ -35,12 +35,11 @@ type VoltStatement struct {
 }
 
 func newVoltStatement(d *Conn, query string) *VoltStatement {
-	var vs = new(VoltStatement)
-	vs.d = d
-	vs.query = query
-	idx := inputFinder.FindAllStringIndex(query, -1)
-	vs.numInput = len(idx)
-	return vs
+	return &VoltStatement{
+		query:    query,
+		numInput: len(inputFinder.FindAllStringIndex(query, -1)),
+		d:        d,
+	}
 }
 
 // Close closes the statement.  Close is a noop for VoltDB as the VoltDB server
@@ -63,9 +62,7 @@ func (vs VoltStatement) Exec(args []driver.Value) (driver.Result, error) {
 // ExecTimeout executes a query that doesn't return rows, such as an INSERT or
 // UPDATE.  Specifies a duration for timeout.
 func (vs VoltStatement) ExecTimeout(args []driver.Value, timeout time.Duration) (driver.Result, error) {
-	args = append(args, "")
-	copy(args[1:], args[0:])
-	args[0] = vs.query
+	args = append([]driver.Value{vs.query}, args...)
 	return vs.d.ExecTimeout("@AdHoc", args, timeout)
 }
 
@@ -77,9 +74,7 @@ func (vs VoltStatement) ExecAsync(resCons AsyncResponseConsumer, args []driver.V
 // ExecAsyncTimeout asynchronously runs an Exec. Specifies a duration for
 // timeout.
 func (vs VoltStatement) ExecAsyncTimeout(resCons AsyncResponseConsumer, args []driver.Value, timeout time.Duration) {
-	args = append(args, "")
-	copy(args[1:], args[0:])
-	args[0] = vs.query
+	args = append([]driver.Value{vs.query}, args...)
 	vs.d.ExecAsyncTimeout(resCons, "@AdHoc", args, timeout)
 }
 
@@ -92,9 +87,7 @@ func (vs VoltStatement) Query(args []driver.Value) (driver.Rows, error) {
 // QueryTimeout executes a query that may return rows, such as a SELECT.
 // Specifies a duration for timeout.
 func (vs VoltStatement) QueryTimeout(args []driver.Value, timeout time.Duration) (driver.Rows, error) {
-	args = append(args, "")
-	copy(args[1:], args[0:])
-	args[0] = vs.query
+	args = append([]driver.Value{vs.query}, args...)
 	return vs.d.QueryTimeout("@AdHoc", args, timeout)
 }
 
@@ -106,8 +99,6 @@ func (vs VoltStatement) QueryAsync(rowsCons AsyncResponseConsumer, args []driver
 // QueryAsyncTimeout asynchronously runs a Query. Specifies a duration for
 // timeout.
 func (vs VoltStatement) QueryAsyncTimeout(rowsCons AsyncResponseConsumer, args []driver.Value, timeout time.Duration) {
-	args = append(args, "")
-	copy(args[1:], args[0:])
-	args[0] = vs.query
+	args = append([]driver.Value{vs.query}, args...)
 	vs.d.QueryAsyncTimeout(rowsCons, "@AdHoc", args, timeout)
 }

--- a/voltdbclient/table.go
+++ b/voltdbclient/table.go
@@ -40,19 +40,20 @@ type voltTable struct {
 }
 
 func newVoltTable(columnCount int16, columnTypes []int8, columnNames []string, rowCount int32, rows [][]byte) *voltTable {
-	var vt = new(voltTable)
-	vt.columnCount = columnCount
-	vt.columnTypes = columnTypes
-	vt.columnNames = columnNames
-	vt.numRows = rowCount
-	vt.rows = rows
+	var vt = &voltTable{
+		columnCount: columnCount,
+		columnTypes: columnTypes,
+		columnNames: columnNames,
+		numRows:     rowCount,
+		rows:        rows,
+		rowIndex:    invalidRowIndex,
+		cnToCi:      make(map[string]int16),
+	}
 
 	// store columnName to columnIndex
-	vt.cnToCi = make(map[string]int16)
 	for ci, cn := range columnNames {
 		vt.cnToCi[cn] = int16(ci)
 	}
-	vt.rowIndex = invalidRowIndex
 	return vt
 }
 

--- a/voltdbclient/utils.go
+++ b/voltdbclient/utils.go
@@ -60,10 +60,10 @@ func clear(v interface{}) {
 func fromGzip(compressed []byte) ([]byte, error) {
 	var b = bytes.NewReader(compressed)
 	r, err := gzip.NewReader(b)
-	defer r.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer r.Close()
 	decompressed, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixed issue in the rare case that `gzip.NewReader` returns an error, the `fromGzip()` function in `utils.go` would panic by trying to call `Close` on a nil reader. 

Various refactoring to make the code more idiomatic (specifically the way that structs and struct pointers are initialized).

Altered the unshift logic used in `VoltStatement` and arguments, to be faster and easier to read.

