### PR TITLE
Fixed Connection Handling in Cluster Mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,10 @@ cpu: clean
 # Installs benchcmp tool
 deps:
 	go get golang.org/x/tools/cmd/benchcmp
+
+down:
+	voltadmin shutdown
+
+voter:
+	go install ./examples/voter
+	./voter --runtype=sync --servers="localhost:21212,localhost:21222,localhost:21232"

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ down:
 
 voter:
 	go install ./examples/voter
-	./voter --runtype=sync --servers="localhost:21212,localhost:21222,localhost:21232"
+	voter --runtype=sync --servers="localhost:21212,localhost:21222,localhost:21232"

--- a/examples/voter/benchmark_runner.go
+++ b/examples/voter/benchmark_runner.go
@@ -299,7 +299,7 @@ func handleSQLRows(rows *sql.Rows, err error) (success int) {
 }
 
 func handleVoteError(err error) (success int) {
-	log.Panic(err)
+	log.Println(err)
 	atomic.AddUint64(&(fullStats.failedVotes), 1)
 	return 0
 }

--- a/examples/voter/benchmark_runner.go
+++ b/examples/voter/benchmark_runner.go
@@ -397,12 +397,14 @@ func printResults(timeElapsed time.Duration) {
 	// 2. Voting results
 	rows, err := bm.conn.Query("Results", []driver.Value{})
 	if err != nil {
-		if strings.Contains(err.Error(), "write: broken pipe") {
+		if strings.Contains(err.Error(), "is down") {
 			rows, err = bm.conn.Query("Results", []driver.Value{})
 			if err != nil {
 				bm.conn.DumpConn()
 				log.Fatal(err, rows == nil)
 			}
+		} else {
+			log.Fatal(err)
 		}
 	}
 

--- a/examples/voter/benchmark_runner.go
+++ b/examples/voter/benchmark_runner.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	"runtime"
 	"runtime/pprof"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -396,7 +397,13 @@ func printResults(timeElapsed time.Duration) {
 	// 2. Voting results
 	rows, err := bm.conn.Query("Results", []driver.Value{})
 	if err != nil {
-		log.Fatal(err)
+		if strings.Contains(err.Error(), "write: broken pipe") {
+			rows, err = bm.conn.Query("Results", []driver.Value{})
+			if err != nil {
+				bm.conn.DumpConn()
+				log.Fatal(err, rows == nil)
+			}
+		}
 	}
 
 	fmt.Println("Contestant Name\t\tVotes Received")

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -167,6 +167,9 @@ func (c *Conn) DumpConn() {
 
 //Returns a node connection that is not closed.
 func (c *Conn) getConn() *nodeConn {
+	if len(c.connected) == 1 {
+		return c.connected[0]
+	}
 	size := len(c.connected)
 	idx := rand.Intn(size)
 	nc := c.connected[idx]

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -173,8 +173,9 @@ func (c *Conn) getConn() *nodeConn {
 	if nc.isClosed() {
 		for {
 			n := rand.Intn(size)
-			if n != idx {
-				return c.connected[n]
+			nc = c.connected[n]
+			if !nc.isClosed() {
+				return nc
 			}
 		}
 	}

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -186,13 +186,6 @@ func (c *Conn) loop(disconnected []*nodeConn, hostIDToConnection *map[int]*nodeC
 
 	// TODO: resubsribe when we lose the subscribed connection
 	var (
-		// subscribedConnection *nodeConn
-		// subTopoCh   <-chan voltResponse
-		// topoStatsCh <-chan voltResponse
-		// hasTopoStats   bool
-		// prInfoCh <-chan voltResponse
-		// fetchedCatalog bool
-
 		closeRespCh           chan bool
 		closingNcsCh          chan bool
 		outstandingCloseCount int
@@ -201,12 +194,6 @@ func (c *Conn) loop(disconnected []*nodeConn, hostIDToConnection *map[int]*nodeC
 		drainRespCh           chan bool
 		drainingNcsCh         chan bool
 		outstandingDrainCount int
-
-		// hnator            hashinator
-		// partitionReplicas *map[int][]*nodeConn
-		// partitionMasters = make(map[int]*nodeConn)
-
-		// procedureInfos *map[string]procedure
 	)
 
 	for {
@@ -219,8 +206,6 @@ func (c *Conn) loop(disconnected []*nodeConn, hostIDToConnection *map[int]*nodeC
 		}
 		select {
 		case closeRespCh = <-c.closeCh:
-			// c.inPiCh = nil
-			// c.allNcsPiCh = nil
 			c.drainCh = nil
 			c.closeCh = nil
 			if len(c.connected) == 0 {

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -103,6 +103,19 @@ func newConn(cis []string) (*Conn, error) {
 //
 // You can omit the port,and the default port of 21212 will be automatically
 // added for you.
+//
+// Additionally you can fine tune behavior of connections when in cluster mode
+// using query parameters.
+//
+// Example localhost:21212?max_retries=10&retry=true&retry_interval=1s
+//
+// retry - if true will try to reconnect with the node when the connection is
+// lost.
+//
+// max_retries - in the number of times you want to retry to connect to a node.
+// This has no effect when retry is false.
+//
+// retry_interval is the duration of time to wait until the next retry.
 func OpenConn(ci string) (*Conn, error) {
 	ci = strings.TrimSpace(ci)
 	if ci == "" {

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -313,7 +313,7 @@ func (c *Conn) loop(disconnected []*nodeConn, hostIDToConnection *map[int]*nodeC
 	// check error channel to see if any lost connections.
 }
 
-func (c *Conn) submit(pi *procedureInvocation) {
+func (c *Conn) submit(pi *procedureInvocation) (int, error) {
 	var nc *nodeConn
 	var backpressure = true
 	var err error
@@ -326,7 +326,7 @@ func (c *Conn) submit(pi *procedureInvocation) {
 	} else {
 		// c.allNcsPiCh <- pi
 	}
-	c.subscribedConnection.submit(pi)
+	return c.subscribedConnection.submit(pi)
 }
 
 // Begin starts a transaction.

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -159,6 +159,12 @@ func (c *Conn) start(cis []string) error {
 	return nil
 }
 
+func (c *Conn) DumpConn() {
+	for _, v := range c.connected {
+		fmt.Println(v.connInfo, v.isClosed())
+	}
+}
+
 //Returns a node connection that is not closed.
 func (c *Conn) getConn() *nodeConn {
 	size := len(c.connected)

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -19,6 +19,7 @@ package voltdbclient
 
 import (
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -34,6 +35,8 @@ const (
 
 var handle int64
 var sHandle int64 = -1
+
+var ErrMissingServerArgument = errors.New("voltdbclient: missing voltdb connection string")
 
 // ProtocolVersion lists the version of the voltdb wire protocol to use.
 // For VoltDB releases of version 5.2 and later use version 1. For releases
@@ -101,6 +104,10 @@ func newConn(cis []string) (*Conn, error) {
 // You can omit the port,and the default port of 21212 will be automatically
 // added for you.
 func OpenConn(ci string) (*Conn, error) {
+	ci = strings.TrimSpace(ci)
+	if ci == "" {
+		return nil, ErrMissingServerArgument
+	}
 	cis := strings.Split(ci, ",")
 	return newConn(cis)
 }

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -133,9 +133,7 @@ func (c *Conn) start(cis []string) error {
 	)
 
 	for _, ci := range cis {
-		ncPiCh := make(chan *procedureInvocation, 1000)
-		nc := newNodeConn(ci, ncPiCh)
-
+		nc := newNodeConn(ci)
 		if err = nc.connect(ProtocolVersion); err != nil {
 			disconnected = append(disconnected, nc)
 			continue

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -116,6 +116,10 @@ func OpenConn(ci string) (*Conn, error) {
 // This connection will try to meet the specified latency target, potentially by
 // throttling the rate at which asynchronous transactions are submitted.
 func OpenConnWithLatencyTarget(ci string, latencyTarget int32) (*Conn, error) {
+	ci = strings.TrimSpace(ci)
+	if ci == "" {
+		return nil, ErrMissingServerArgument
+	}
 	cis := strings.Split(ci, ",")
 	c, err := newConn(cis)
 	if err != nil {
@@ -130,6 +134,10 @@ func OpenConnWithLatencyTarget(ci string, latencyTarget int32) (*Conn, error) {
 // indicated. An outstanding transaction is a transaction that has been sent to
 // the server but for which no response has been received.
 func OpenConnWithMaxOutstandingTxns(ci string, maxOutTxns int) (*Conn, error) {
+	ci = strings.TrimSpace(ci)
+	if ci == "" {
+		return nil, ErrMissingServerArgument
+	}
 	cis := strings.Split(ci, ",")
 	c, err := newConn(cis)
 	if err != nil {

--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -235,7 +235,7 @@ func (nc *nodeConn) loop(bpCh <-chan chan bool, drainCh chan chan bool) {
 				// TODO: should disconnect
 			}
 		} else if pingSinceSent > pingTimeout/3 {
-			nc.sendPing(nc.tcpConn)
+			nc.sendPing()
 			pingOutstanding = true
 			pingSentTime = time.Now()
 		}
@@ -371,14 +371,14 @@ func (nc *nodeConn) handleTimeout(req *networkRequest) {
 }
 
 func (nc *nodeConn) Ping() error {
-	return nc.sendPing(nc.tcpConn)
+	return nc.sendPing()
 }
 
-func (nc *nodeConn) sendPing(writer io.Writer) error {
+func (nc *nodeConn) sendPing() error {
 	pi := newProcedureInvocationByHandle(PingHandle, true, "@Ping", []driver.Value{})
 	encoder := wire.NewEncoder()
 	EncodePI(encoder, pi)
-	_, err := writer.Write(encoder.Bytes())
+	_, err := nc.tcpConn.Write(encoder.Bytes())
 	if err != nil {
 		if strings.Contains(err.Error(), "write: broken pipe") {
 			return fmt.Errorf("node %s: is down", nc.connInfo)

--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -39,10 +39,9 @@ const maxQueuedBytes = 262144
 const maxResponseBuffer = 10000
 
 type nodeConn struct {
-	connInfo string
-	connData *wire.ConnInfo
-	tcpConn  *net.TCPConn
-
+	connInfo     string
+	connData     *wire.ConnInfo
+	tcpConn      *net.TCPConn
 	drainCh      chan chan bool
 	bpCh         chan chan bool
 	closeCh      chan chan bool
@@ -183,13 +182,8 @@ func (nc *nodeConn) listen() {
 }
 
 func (nc *nodeConn) loop(bpCh <-chan chan bool, drainCh chan chan bool) {
-	// declare mutable state
-	// requests := make(map[int64]*networkRequest)
-	// ncPiCh := nc.ncPiCh
 	var draining bool
 	var drainRespCh chan bool
-	// var queuedBytes int
-	// var bp bool
 
 	var tci = int64(DefaultQueryTimeout / 10)                    // timeout check interval
 	tcc := time.NewTimer(time.Duration(tci) * time.Nanosecond).C // timeout check timer channel
@@ -208,14 +202,6 @@ func (nc *nodeConn) loop(bpCh <-chan chan bool, drainCh chan chan bool) {
 			}
 		}
 
-		// if nc.queuedBytes > maxQueuedBytes && ncPiCh != nil {
-		// 	ncPiCh = nil
-		// 	nc.bp = true
-		// } else if ncPiCh == nil {
-		// 	ncPiCh = nc.ncPiCh
-		// 	nc.bp = false
-		// }
-
 		// ping
 		pingSinceSent := time.Now().Sub(pingSentTime)
 		if pingOutstanding {
@@ -233,8 +219,6 @@ func (nc *nodeConn) loop(bpCh <-chan chan bool, drainCh chan chan bool) {
 			nc.tcpConn.Close()
 			respCh <- true
 			return
-		// case pi := <-ncPiCh:
-		// 	nc.handleProcedureInvocation(pi)
 		case resp := <-nc.responseCh:
 			decoder := wire.NewDecoder(resp)
 			handle, err := decoder.Int64()

--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -142,6 +142,7 @@ func (nc *nodeConn) reconnect(protocolVersion int) {
 		}
 		count := 0
 		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:

--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -52,10 +52,10 @@ type nodeConn struct {
 	queuedBytes int
 }
 
-func newNodeConn(ci string, ncPiCh chan *procedureInvocation) *nodeConn {
+func newNodeConn(ci string) *nodeConn {
 	return &nodeConn{
 		connInfo:   ci,
-		ncPiCh:     ncPiCh,
+		ncPiCh:     make(chan *procedureInvocation, 1000),
 		bpCh:       make(chan chan bool),
 		closeCh:    make(chan chan bool),
 		drainCh:    make(chan chan bool),

--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -176,6 +176,9 @@ func (nc *nodeConn) listen() {
 	d := wire.NewDecoder(nc.tcpConn)
 	s := &wire.Decoder{}
 	for {
+		if nc.isClosed() {
+			return
+		}
 		b, err := d.Message()
 		if err != nil {
 			if nc.responseCh == nil {
@@ -211,6 +214,9 @@ func (nc *nodeConn) loop(bpCh <-chan chan bool, drainCh chan chan bool) {
 	pingSentTime := time.Now()
 	var pingOutstanding bool
 	for {
+		if nc.isClosed() {
+			return
+		}
 		// setup select cases
 		if draining {
 			if nc.queuedBytes == 0 {

--- a/voltdbclient/node_conn_test.go
+++ b/voltdbclient/node_conn_test.go
@@ -7,9 +7,8 @@ import (
 
 func TestNodeConn_Close(t *testing.T) {
 	conn := "localhost:21212"
-	c := newNodeConn(conn, nil)
-	i := make(chan *procedureInvocation)
-	err := c.connect(1, i)
+	c := newNodeConn(conn)
+	err := c.connect(1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/voltdbclient/node_conn_test.go
+++ b/voltdbclient/node_conn_test.go
@@ -1,8 +1,11 @@
 package voltdbclient
 
 import (
+	"fmt"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNodeConn_Close(t *testing.T) {
@@ -28,5 +31,30 @@ func TestNodeConn_Close(t *testing.T) {
 		if !strings.Contains(err.Error(), e) {
 			t.Errorf("expected %s to be in %v", e, err)
 		}
+	}
+}
+func TestNodeRetries(t *testing.T) {
+	n := 10
+	query := make(url.Values)
+	query.Set("retry", "true")
+	query.Set("retry_interval", time.Second.String())
+	query.Set("max_retries", fmt.Sprint(n))
+	conn := "localhost:21212?" + query.Encode()
+	c := newNodeConn(conn)
+	err := c.connect(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		<-c.close()
+	}()
+	if !c.retry {
+		t.Error("expected retry to be true")
+	}
+	if c.retryInterval != time.Second {
+		t.Errorf("expected %v got %v", time.Second, c.retryInterval)
+	}
+	if c.maxRetries != n {
+		t.Errorf("expected %d got %d", n, c.maxRetries)
 	}
 }

--- a/voltdbclient/procedure_invocation.go
+++ b/voltdbclient/procedure_invocation.go
@@ -34,6 +34,7 @@ type procedureInvocation struct {
 	arc        AsyncResponseConsumer
 	async      bool
 	slen       int // length of pi once serialized
+	conn       *nodeConn
 }
 
 func newSyncProcedureInvocation(handle int64, isQuery bool, query string, params []driver.Value, responseCh chan voltResponse, timeout time.Duration) *procedureInvocation {

--- a/voltdbclient/procedure_invocation.go
+++ b/voltdbclient/procedure_invocation.go
@@ -25,16 +25,26 @@ import (
 )
 
 type procedureInvocation struct {
-	handle     int64
-	isQuery    bool // as opposed to an exec.
-	query      string
-	params     []driver.Value
+
+	// This is a unique integer that is used to identify the procedure invocation.
+	handle  int64
+	isQuery bool // as opposed to an exec.
+
+	// The SQL query to be sent to voltdb
+	query  string
+	params []driver.Value
+
+	// The channel on which response from voltdb will be sent. The node connection
+	// thwt will write on this channel is stored in the conn field.
 	responseCh chan voltResponse
 	timeout    time.Duration
 	arc        AsyncResponseConsumer
 	async      bool
 	slen       int // length of pi once serialized
-	conn       *nodeConn
+
+	// This is the connection that received the invocation request. It is through
+	// this connection that the response to the procedure invocation will be sent.
+	conn *nodeConn
 }
 
 func newSyncProcedureInvocation(handle int64, isQuery bool, query string, params []driver.Value, responseCh chan voltResponse, timeout time.Duration) *procedureInvocation {

--- a/voltdbclient/query_api.go
+++ b/voltdbclient/query_api.go
@@ -118,7 +118,7 @@ func (c *Conn) QueryTimeout(query string, args []driver.Value, timeout time.Dura
 	tm := time.NewTimer(pi.timeout)
 	defer tm.Stop()
 	sec := time.NewTicker(time.Second)
-	defer tm.Stop()
+	defer sec.Stop()
 	for {
 		if pi.conn.isClosed() {
 			return nil, VoltError{voltResponse: voltResponseInfo{status: ConnectionTimeout, clusterRoundTripTime: -1},

--- a/voltdbclient/query_api.go
+++ b/voltdbclient/query_api.go
@@ -23,6 +23,8 @@ import (
 	"time"
 )
 
+var errTimeoutExecutingQuery = errors.New("voltdbclient: Timed out executing query")
+
 // Exec executes a query that doesn't return rows, such as an INSERT or UPDATE.
 // Exec is available on both VoltConn and on VoltStatement.
 // Uses DefaultQueryTimeout.
@@ -36,7 +38,10 @@ func (c *Conn) Exec(query string, args []driver.Value) (driver.Result, error) {
 func (c *Conn) ExecTimeout(query string, args []driver.Value, timeout time.Duration) (driver.Result, error) {
 	responseCh := make(chan voltResponse, 1)
 	pi := newSyncProcedureInvocation(c.getNextHandle(), false, query, args, responseCh, timeout)
-	c.inPiCh <- pi
+	_, err := c.submit(pi)
+	if err != nil {
+		return nil, err
+	}
 	tm := time.NewTimer(pi.timeout)
 	defer tm.Stop()
 	select {
@@ -64,9 +69,10 @@ func (c *Conn) ExecAsync(resCons AsyncResponseConsumer, query string, args []dri
 // ExecAsyncTimeout is analogous to Exec but is run asynchronously.  That is, an
 // invocation of this method blocks only until a request is sent to the VoltDB
 // server.  Specifies a duration for timeout.
-func (c *Conn) ExecAsyncTimeout(resCons AsyncResponseConsumer, query string, args []driver.Value, timeout time.Duration) {
+func (c *Conn) ExecAsyncTimeout(resCons AsyncResponseConsumer, query string, args []driver.Value, timeout time.Duration) error {
 	pi := newAsyncProcedureInvocation(c.getNextHandle(), false, query, args, timeout, resCons)
-	c.inPiCh <- pi
+	_, err := c.submit(pi)
+	return err
 }
 
 // Prepare creates a prepared statement for later queries or executions.
@@ -89,21 +95,24 @@ func (c *Conn) Query(query string, args []driver.Value) (driver.Rows, error) {
 func (c *Conn) QueryTimeout(query string, args []driver.Value, timeout time.Duration) (driver.Rows, error) {
 	responseCh := make(chan voltResponse, 1)
 	pi := newSyncProcedureInvocation(c.getNextHandle(), true, query, args, responseCh, timeout)
-	c.inPiCh <- pi
+	_, err := c.submit(pi)
+	if err != nil {
+		return nil, err
+	}
 	tm := time.NewTimer(pi.timeout)
 	defer tm.Stop()
 	select {
 	case resp := <-pi.responseCh:
-		switch resp.(type) {
+		switch e := resp.(type) {
 		case VoltRows:
-			return resp.(VoltRows), nil
+			return e, nil
 		case VoltError:
-			return nil, resp.(VoltError)
+			return nil, e
 		default:
 			panic("unexpected response type")
 		}
 	case <-tm.C:
-		return nil, VoltError{voltResponse: voltResponseInfo{status: ConnectionTimeout, clusterRoundTripTime: -1}, error: errors.New("timeout")}
+		return nil, VoltError{voltResponse: voltResponseInfo{status: ConnectionTimeout, clusterRoundTripTime: -1}, error: errTimeoutExecutingQuery}
 	}
 }
 
@@ -119,7 +128,8 @@ func (c *Conn) QueryAsync(rowsCons AsyncResponseConsumer, query string, args []d
 // block until the query is sent over the network to the server.  The eventual
 // response will be handled by the given AsyncResponseConsumer, this processing
 // happens in the 'response' thread.  Specifies a duration for timeout.
-func (c *Conn) QueryAsyncTimeout(rowsCons AsyncResponseConsumer, query string, args []driver.Value, timeout time.Duration) {
+func (c *Conn) QueryAsyncTimeout(rowsCons AsyncResponseConsumer, query string, args []driver.Value, timeout time.Duration) error {
 	pi := newAsyncProcedureInvocation(c.getNextHandle(), true, query, args, timeout, rowsCons)
-	c.inPiCh <- pi
+	_, err := c.submit(pi)
+	return err
 }

--- a/voltdbclient/query_api.go
+++ b/voltdbclient/query_api.go
@@ -114,7 +114,7 @@ func (c *Conn) QueryTimeout(query string, args []driver.Value, timeout time.Dura
 	// of querying voltdb in this client.
 	//
 	// What happens here is, we invoke the procedure invocation and wait until we
-	// receive a response on the procedureInvocation channel.
+	// receive a response on the responseCh channel.
 	// The call to c.submit ensures that the procedure invocation request did hit a
 	// voltdb host.
 	//


### PR DESCRIPTION
This makes Query* and Exec* calls  ensure the request was received by the database server. They should return any errors encountered when writing to the tcp connections.
