### PR TITLE
fix running async benchmark in cluster mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ voter:
 	go install ./examples/voter
 	voter --runtype=sync  --servers="localhost:21212,localhost:21222,localhost:21232" --memprofile="mem.out"
 
+voter-sql:
+	go install ./examples/voter
+	voter --runtype=sql --servers="localhost:21212,localhost:21222,localhost:21232" --memprofile="mem.out"
+
 voter-async:
 	go install ./examples/voter
-	voter --runtype=async  --goroutines=10   --memprofile=mem.out --servers="localhost:21212,localhost:21222,localhost:21232" --memprofile="mem.out"
+	voter --runtype=async  --servers="localhost:21212,localhost:21222,localhost:21232" --memprofile="mem.out"

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,8 @@ down:
 
 voter:
 	go install ./examples/voter
-	voter --runtype=sync --servers="localhost:21212,localhost:21222,localhost:21232"
+	voter --runtype=sync  --servers="localhost:21212,localhost:21222,localhost:21232" --memprofile="mem.out"
+
+voter-async:
+	go install ./examples/voter
+	voter --runtype=async  --goroutines=10   --memprofile=mem.out --servers="localhost:21212,localhost:21222,localhost:21232" --memprofile="mem.out"

--- a/examples/voter/benchmark_runner.go
+++ b/examples/voter/benchmark_runner.go
@@ -383,7 +383,6 @@ func printResults(timeElapsed time.Duration) {
 		if strings.Contains(err.Error(), "is down") {
 			rows, err = bm.conn.Query("Results", []driver.Value{})
 			if err != nil {
-				bm.conn.DumpConn()
 				log.Fatal(err, rows == nil)
 			}
 		} else {

--- a/examples/voter/voter_config.go
+++ b/examples/voter/voter_config.go
@@ -64,7 +64,7 @@ func newVoterConfig() (*voterConfig, error) {
 	flag.IntVar(&(voter.contestants), "contestants", 6, "Number of contestants in the voting contest (from 1 to 10).")
 	flag.IntVar(&(voter.maxvotes), "maxvotes", 2, "Maximum number of votes cast per voter.")
 	flag.StringVar(&(voter.statsfile), "statsfile", "", "Filename to write raw summary statistics to.")
-	flag.IntVar(&(voter.goroutines), "goroutines", 40, "Number of concurrent goroutines synchronously calling procedures.")
+	flag.IntVar(&(voter.goroutines), "goroutines", 10, "Number of concurrent goroutines synchronously calling procedures.")
 	flag.Var(&(voter.runtype), "runtype", "Type of the client calling procedures.")
 	flag.Parse()
 

--- a/examples/voter/voter_config.go
+++ b/examples/voter/voter_config.go
@@ -67,7 +67,11 @@ func newVoterConfig() (*voterConfig, error) {
 	flag.IntVar(&(voter.goroutines), "goroutines", 10, "Number of concurrent goroutines synchronously calling procedures.")
 	flag.Var(&(voter.runtype), "runtype", "Type of the client calling procedures.")
 	flag.Parse()
-
+	if voter.runtype == "async" {
+		if voter.goroutines == 10 {
+			voter.goroutines = 3
+		}
+	}
 	// validate
 	switch {
 	case (voter.displayinterval <= 0):

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -239,6 +239,10 @@ func (c *Conn) loop(disconnected []*nodeConn, hostIDToConnection *map[int]*nodeC
 			if len(c.connected) == 0 {
 				closeRespCh <- true
 			} else {
+
+				// We make sure all node connections managed by this Conn object are closed.
+				// This will block, it is okay though since we are closing the connection
+				// which means we don't want anything else to be happening.
 				for _, connectedNc := range c.connected {
 					<-connectedNc.close()
 				}

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -187,12 +187,6 @@ func (c *Conn) start(cis []string) error {
 	return nil
 }
 
-func (c *Conn) DumpConn() {
-	for _, v := range c.connected {
-		fmt.Println(v.connInfo, v.isClosed())
-	}
-}
-
 //Returns a node connection that is not closed.
 func (c *Conn) getConn() *nodeConn {
 	if len(c.connected) == 1 {

--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -92,6 +92,12 @@ func (nc *nodeConn) submit(pi *procedureInvocation) (int, error) {
 func (nc *nodeConn) markClosed() {
 	nc.closed.Store(true)
 	nc.tcpConn.Close()
+
+	// release all stored pending requests. This connection is closed so we can't
+	// satisfy the requests.
+	//
+	// TODO: handle the requests with connection closed error?
+	nc.requests = &sync.Map{}
 }
 
 func (nc *nodeConn) isClosed() bool {

--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -120,7 +120,7 @@ func (nc *nodeConn) connect(protocolVersion int) error {
 
 	nc.drainCh = make(chan chan bool, 1)
 
-	go nc.loop(nc.bpCh, nc.drainCh)
+	go nc.loop(nc.bpCh)
 	return nil
 }
 
@@ -158,7 +158,7 @@ func (nc *nodeConn) reconnect(protocolVersion int) {
 				nc.tcpConn = tcpConn
 				nc.connData = connData
 				go nc.listen()
-				go nc.loop(nc.bpCh, nc.drainCh)
+				go nc.loop(nc.bpCh)
 				nc.closed.Store(false)
 				return
 			}
@@ -267,7 +267,7 @@ func (nc *nodeConn) listen() {
 	}
 }
 
-func (nc *nodeConn) loop(bpCh <-chan chan bool, drainCh chan chan bool) {
+func (nc *nodeConn) loop(bpCh <-chan chan bool) {
 	var draining bool
 	var drainRespCh chan bool
 
@@ -284,7 +284,7 @@ func (nc *nodeConn) loop(bpCh <-chan chan bool, drainCh chan chan bool) {
 		}
 		// setup select cases
 		if draining {
-			if nc.queuedBytes == 0 {
+			if nc.queuedBytes <= 0 {
 				drainRespCh <- true
 				drainRespCh = nil
 				draining = false
@@ -337,7 +337,7 @@ func (nc *nodeConn) loop(bpCh <-chan chan bool, drainCh chan chan bool) {
 
 		case respBPCh := <-bpCh:
 			respBPCh <- nc.bp
-		case drainRespCh = <-drainCh:
+		case drainRespCh = <-nc.drainCh:
 			draining = true
 		// check for timed out procedure invocations
 		case <-tcc:


### PR DESCRIPTION
@abradley201 this is ready for review/testing/merging.

__NOTE__ The throughput for sql and sync is shows to be lower. My fix on the benchmark suite was more focused on correctness of the benchmark logic. So The numbers we get here are probably almost what the previous author intended to reflect on the benchmark, but couldn't because os misuse of  go concurrency primitives.


The number `10` of goroutines was found through trial and error. The main focus was to run the benchmark in the same machine. Voltdb works in memory, add replication to three node it is easy to run out of memory. So with 10 go routines I was able to successful run `sql`,`sync` and `async` in reliable manner.

The memory leak for `async` is gone, the culpit was mishandling of `draining`  of connections.