### PR TITLE
adds implementation of driver.RowsNextResultSet interface

### DIFF
--- a/voltdbclient/client_test.go
+++ b/voltdbclient/client_test.go
@@ -336,7 +336,7 @@ func TestOpenAuth(t *testing.T) {
 	}
 }
 
-func TestMultiResultSet(t *testing.T) {
+func TestRowsNextResultSet(t *testing.T) {
 	const (
 		rowSets = 3
 		rowCnt  = 100

--- a/voltdbclient/query_api.go
+++ b/voltdbclient/query_api.go
@@ -148,7 +148,7 @@ func (c *Conn) QueryTimeout(query string, args []driver.Value, timeout time.Dura
 		case resp := <-pi.responseCh:
 			switch e := resp.(type) {
 			case VoltRows:
-				return e, nil
+				return &e, nil
 			case VoltError:
 				return nil, e
 			default:

--- a/voltdbclient/rows.go
+++ b/voltdbclient/rows.go
@@ -34,6 +34,11 @@ var nullDecimal = [...]byte{128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 var nullTimestamp = [...]byte{128, 0, 0, 0, 0, 0, 0, 0}
 var order = binary.BigEndian
 
+var (
+	_ driver.Rows              = VoltRows{}
+	_ driver.RowsNextResultSet = &VoltRows{}
+)
+
 // VoltRows is an implementation of database/sql/driver.Rows.
 //
 // A response to a query from the VoltDB server might include rows from more
@@ -498,7 +503,7 @@ func bytesToTime(bs []byte) time.Time {
 }
 
 // HasNextResultSet implements driver.RowsNextResultSet
-func (vr *VoltRows) HasNextResultSet() bool {
+func (vr VoltRows) HasNextResultSet() bool {
 	return (vr.tableIndex != -1) && vr.tableIndex+1 < vr.getNumTables()
 }
 

--- a/voltdbclient/rows.go
+++ b/voltdbclient/rows.go
@@ -496,3 +496,16 @@ func bytesToTime(bs []byte) time.Time {
 	// time.Unix will take either seconds or nanos. Multiply by 1000 and use nanos.
 	return time.Unix(0, millis*1000)
 }
+
+// HasNextResultSet implements driver.RowsNextResultSet
+func (vr *VoltRows) HasNextResultSet() bool {
+	return vr.tableIndex+1 < vr.getNumTables()
+}
+
+// NextResultSet implements driver.RowsNextResultSet
+func (vr *VoltRows) NextResultSet() error {
+	if !vr.AdvanceToTable(vr.tableIndex + 1) {
+		return io.EOF
+	}
+	return nil
+}

--- a/voltdbclient/rows.go
+++ b/voltdbclient/rows.go
@@ -499,7 +499,7 @@ func bytesToTime(bs []byte) time.Time {
 
 // HasNextResultSet implements driver.RowsNextResultSet
 func (vr *VoltRows) HasNextResultSet() bool {
-	return vr.tableIndex+1 < vr.getNumTables()
+	return (vr.tableIndex != -1) && vr.tableIndex+1 < vr.getNumTables()
 }
 
 // NextResultSet implements driver.RowsNextResultSet


### PR DESCRIPTION
Go's database/sql package supports multiple resultsets. 

To enable this feature the driver.RowsNextResultSet interface must be implemented by the database driver. This PR adds the implementation for this.