### PR TITLE
Fixed case inconsistency of column names

### DIFF
--- a/voltdbclient/table.go
+++ b/voltdbclient/table.go
@@ -20,6 +20,7 @@ package voltdbclient
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/VoltDB/voltdb-client-go/wire"
 )
@@ -52,7 +53,7 @@ func newVoltTable(columnCount int16, columnTypes []int8, columnNames []string, r
 
 	// store columnName to columnIndex
 	for ci, cn := range columnNames {
-		vt.cnToCi[cn] = int16(ci)
+		vt.cnToCi[strings.ToUpper(cn)] = int16(ci)
 	}
 	return vt
 }


### PR DESCRIPTION
 I suggest small fixing in the request.

 In the go-version client, I've found inconsistency of the case between creating index for columns and looking up column by name. Our situation occurs that lower cases column name in VoltTables which would be returned in stored procedue. In Java client, it is no problem to get column value by lower cases column name. (It might be bad manner...)

more details in my case,
A part of code in my procedure...
```
public class VoltTable[] run (long id) {
    VoltTable ret = new VoltTable( new VoltTable.ColumnInfo("srcip", VoltType.STRING),
                                   new VoltTable.ColumnInfo("bytesum", VoltType.BIGINT) );

    ...

    return new VoltTable[] { ret }
}
```
then in go-client,

voltRows.GetStringByName("srcip") returns error `column name srcip was not found`