### PR TITLE
ENG-23794, remove sha1 support from go client

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,6 @@ import (
 )
 
 func main() {
-	// If using a version of VoltDB server prior to 5.2, then
-	// set the version of the wire protocol to 0.  The default
-	// value 1, indicates a server version of 5.2 or later.
-	// voltdbclient.ProtocolVersion = 0
-
 	db, err := sql.Open("voltdb", "localhost:21212")
 	if err != nil {
 		log.Fatal(err)

--- a/voltdbclient/distributor.go
+++ b/voltdbclient/distributor.go
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2022 Volt Active Data Inc.
+ * Copyright (C) 2008-2025 Volt Active Data Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -43,8 +43,8 @@ var sHandle int64 = -1
 var ErrMissingServerArgument = errors.New("voltdbclient: missing voltdb connection string")
 
 // ProtocolVersion lists the version of the voltdb wire protocol to use.
-// For VoltDB releases of version 5.2 and later use version 1. For releases
-// prior to that use version 0.
+// Version 0 (VoltDB releases prior to 5.2) is no longer supported.
+// Releases of version 5.2 and later use version 1.
 var ProtocolVersion = 1
 
 // Conn holds the set of currently active connections.

--- a/voltdbclient/node_conn.go
+++ b/voltdbclient/node_conn.go
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2022 Volt Active Data Inc.
+ * Copyright (C) 2008-2025 Volt Active Data Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -166,6 +166,10 @@ func (nc *nodeConn) close() chan bool {
 }
 
 func (nc *nodeConn) connect(protocolVersion int) error {
+	if protocolVersion == 0 {
+		return errors.New("Protocol version 0 is no longer supported")
+	}
+
 	connInterface, connData, err := nc.networkConnect(protocolVersion)
 	if err != nil {
 		return err

--- a/wire/encoder.go
+++ b/wire/encoder.go
@@ -6,7 +6,6 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"errors"
-	"hash"
 	"math"
 	"reflect"
 	"time"


### PR DESCRIPTION
The go API talks in terms of protocol versions rather than hash schema, so eliminating sha1 means eliminating protocol version 0.